### PR TITLE
Clear workshop Owner upon death

### DIFF
--- a/src/game/gnome.cpp
+++ b/src/game/gnome.cpp
@@ -29,6 +29,8 @@
 #include "../game/plant.h"
 #include "../game/stockpilemanager.h"
 #include "../game/world.h"
+#include "../game/workshop.h"
+#include "../game/workshopmanager.h"
 #include "../gfx/spritefactory.h"
 #include "../gui/strings.h"
 
@@ -714,6 +716,11 @@ CreatureTickResult Gnome::onTick( quint64 tickNumber, bool seasonChanged, bool d
 		{
 			Global::logger().log( LogType::COMBAT, m_name + "died. Bummer!", m_id );
 			m_isDead = true;
+			Workshop* assignedWorkshop  = Global::wsm().workshop( m_assignedWorkshop );
+			if ( assignedWorkshop )
+			{
+				assignedWorkshop->assignGnome( 0 );
+			}
 			// TODO check for other statuses
 		}
 	}

--- a/src/game/gnome.cpp
+++ b/src/game/gnome.cpp
@@ -716,11 +716,6 @@ CreatureTickResult Gnome::onTick( quint64 tickNumber, bool seasonChanged, bool d
 		{
 			Global::logger().log( LogType::COMBAT, m_name + "died. Bummer!", m_id );
 			m_isDead = true;
-			Workshop* assignedWorkshop  = Global::wsm().workshop( m_assignedWorkshop );
-			if ( assignedWorkshop )
-			{
-				assignedWorkshop->assignGnome( 0 );
-			}
 			// TODO check for other statuses
 		}
 	}
@@ -728,6 +723,12 @@ CreatureTickResult Gnome::onTick( quint64 tickNumber, bool seasonChanged, bool d
 	if ( m_isDead )
 	{
 		qDebug() << m_name << " expires " << GameState::tick + Util::ticksPerDay;
+		Workshop* assignedWorkshop = Global::wsm().workshop( m_assignedWorkshop );
+		if ( assignedWorkshop )
+		{
+			assignedWorkshop->assignGnome( 0 );
+			assignWorkshop( 0 );
+		}
 		cleanUpJob( false );
 		updateSprite();
 		m_expires    = GameState::tick + Util::ticksPerDay * 2;

--- a/src/game/gnome.cpp
+++ b/src/game/gnome.cpp
@@ -723,11 +723,12 @@ CreatureTickResult Gnome::onTick( quint64 tickNumber, bool seasonChanged, bool d
 	if ( m_isDead )
 	{
 		qDebug() << m_name << " expires " << GameState::tick + Util::ticksPerDay;
-		Workshop* assignedWorkshop = Global::wsm().workshop( m_assignedWorkshop );
-		if ( assignedWorkshop )
+		for ( Workshop* w: Global::wsm().workshops() )
 		{
-			assignedWorkshop->assignGnome( 0 );
-			assignWorkshop( 0 );
+			if ( w->assignedGnome() == id() )
+			{
+				w->assignGnome( 0 );
+			}
 		}
 		cleanUpJob( false );
 		updateSprite();


### PR DESCRIPTION
Fixes #62 

When Gnome dies check every workshops's `Owner`, and if it's the dead Gnome set it to 0

#### Testing

Get a Crude Work bench
Get a Gnome to work on it
Edit save to assign worshop to Gnome and set hunger to -500
Load Save and step through process with VS debug mode
Gnome dies and `Owner` of the crude workbench is set to 0