### PR TITLE
Clear inventory, equipment and workshop ownership upon death

### DIFF
--- a/src/game/animal.cpp
+++ b/src/game/animal.cpp
@@ -388,7 +388,7 @@ CreatureTickResult Animal::onTick( quint64 tickNumber, bool seasonChanged, bool 
 		if ( status & AS_DEAD )
 		{
 			Global::logger().log( LogType::COMBAT, "The " + m_name + " died. Bummer!", m_id );
-			m_isDead = true;
+			die();
 			// TODO check for other statuses
 		}
 	}
@@ -398,7 +398,7 @@ CreatureTickResult Animal::onTick( quint64 tickNumber, bool seasonChanged, bool 
 		m_lastOnTick = tickNumber;
 		return CreatureTickResult::TODESTROY;
 	}
-	if ( m_isDead )
+	if ( isDead() )
 	{
 		m_lastOnTick = tickNumber;
 		return CreatureTickResult::DEAD;

--- a/src/game/automaton.cpp
+++ b/src/game/automaton.cpp
@@ -229,7 +229,7 @@ void Automaton::updateSprite()
 		}
 	}
 
-	m_spriteID = Global::sf().setCreatureSprite( m_id, def, defBack, m_isDead )->uID;
+	m_spriteID = Global::sf().setCreatureSprite( m_id, def, defBack, isDead() )->uID;
 
 	m_renderParamsChanged = true;
 }

--- a/src/game/canwork.cpp
+++ b/src/game/canwork.cpp
@@ -542,7 +542,6 @@ bool CanWork::dropEquippedItem()
 		}
 
 		inv.putDownItem( equippedItem, m_position );
-		inv.gravity( m_position );
 		inv.setInJob( equippedItem, 0 );
 		inv.setConstructedOrEquipped( equippedItem, false );
 		m_equipment.rightHandHeld.itemID = 0;

--- a/src/game/creature.cpp
+++ b/src/game/creature.cpp
@@ -1066,6 +1066,7 @@ void Creature::die()
 	m_isDead = true;
 	dropInventory();
 	dropEquipment();
+	updateSprite();
 }
 
 void Creature::dropInventory()

--- a/src/game/creature.cpp
+++ b/src/game/creature.cpp
@@ -846,14 +846,14 @@ Position Creature::currentTarget() const
 
 bool Creature::kill( bool nocorpse )
 {
-	if ( !m_toDestroy && !m_isDead )
+	if ( !toDestroy() && !isDead() )
 	{
 		//kill succeeds
 		if( nocorpse )
 		{
-			m_toDestroy = true;
+			destroy();
 		}
-		m_isDead = true;
+		die();
 		return true;
 	}
 	// already dead or something else destroyed it
@@ -1059,6 +1059,13 @@ void Creature::updateAttackValues()
 	m_leftHandAttackValue  = m_leftHandAttackSkill;
 	m_rightHandAttackSkill = getSkillLevel( "Unarmed" );
 	m_rightHandAttackValue = m_rightHandAttackSkill;
+}
+
+void Creature::die()
+{
+	m_isDead = true;
+	dropInventory();
+	dropEquipment();
 }
 
 void Creature::dropInventory()

--- a/src/game/creature.cpp
+++ b/src/game/creature.cpp
@@ -1061,6 +1061,26 @@ void Creature::updateAttackValues()
 	m_rightHandAttackValue = m_rightHandAttackSkill;
 }
 
+void Creature::dropInventory()
+{
+	Inventory &inv = Global::inv();
+	for ( const unsigned int it : inventoryItems() )
+	{
+		inv.putDownItem( it, m_position );
+	}
+	m_inventoryItems.clear();
+}
+
+void Creature::dropEquipment()
+{
+	Inventory& inv = Global::inv();
+	for ( const unsigned int it : m_equipment.wornItems() )
+	{
+		inv.putDownItem( it, m_position );
+	}
+	m_equipment.clearAllItems();
+}
+
 void Creature::addClaimedItem( unsigned int item, unsigned int job )
 {
 	Global::inv().setInJob( item, job );

--- a/src/game/creature.h
+++ b/src/game/creature.h
@@ -415,7 +415,7 @@ protected:
 	QList<unsigned int> m_carriedItems;
 	QList<unsigned int> m_inventoryItems;
 
-	void die();
+	virtual void die();
 
 	void dropInventory();
 	void dropEquipment();

--- a/src/game/creature.h
+++ b/src/game/creature.h
@@ -415,6 +415,9 @@ protected:
 	QList<unsigned int> m_carriedItems;
 	QList<unsigned int> m_inventoryItems;
 
+	void dropInventory();
+	void dropEquipment();
+
 	void addClaimedItem( unsigned int item, unsigned int job );
 	void removeClaimedItem( unsigned int item );
 	void unclaimAll();

--- a/src/game/creature.h
+++ b/src/game/creature.h
@@ -415,6 +415,8 @@ protected:
 	QList<unsigned int> m_carriedItems;
 	QList<unsigned int> m_inventoryItems;
 
+	void die();
+
 	void dropInventory();
 	void dropEquipment();
 

--- a/src/game/gnome.cpp
+++ b/src/game/gnome.cpp
@@ -29,6 +29,8 @@
 #include "../game/plant.h"
 #include "../game/stockpilemanager.h"
 #include "../game/world.h"
+#include "../game/workshop.h"
+#include "../game/workshopmanager.h"
 #include "../gfx/spritefactory.h"
 #include "../gui/strings.h"
 
@@ -868,6 +870,13 @@ void Gnome::die()
 {
 	Creature::die();
 	cleanUpJob( false );
+	for ( Workshop* w : Global::wsm().workshops() )
+	{
+		if ( w->assignedGnome() == id() )
+		{
+			w->assignGnome( 0 );
+		}
+	}
 }
 
 bool Gnome::checkFloor()

--- a/src/game/gnome.cpp
+++ b/src/game/gnome.cpp
@@ -722,6 +722,8 @@ CreatureTickResult Gnome::onTick( quint64 tickNumber, bool seasonChanged, bool d
 	{
 		qDebug() << m_name << " expires " << GameState::tick + Util::ticksPerDay;
 		cleanUpJob( false );
+		dropInventory();
+		dropEquipment();
 		updateSprite();
 		m_expires    = GameState::tick + Util::ticksPerDay * 2;
 		m_lastOnTick = tickNumber;

--- a/src/game/gnome.cpp
+++ b/src/game/gnome.cpp
@@ -238,7 +238,7 @@ void Gnome::updateSprite()
 	m_spriteDef     = createSpriteDef( "Gnome", false );
 	m_spriteDefBack = createSpriteDef( "GnomeBack", true );
 
-	Global::sf().setCreatureSprite( m_id, m_spriteDef, m_spriteDefBack, m_isDead );
+	Global::sf().setCreatureSprite( m_id, m_spriteDef, m_spriteDefBack, isDead() );
 
 	m_renderParamsChanged = true;
 }
@@ -713,17 +713,15 @@ CreatureTickResult Gnome::onTick( quint64 tickNumber, bool seasonChanged, bool d
 		if ( status & AS_DEAD )
 		{
 			Global::logger().log( LogType::COMBAT, m_name + "died. Bummer!", m_id );
-			m_isDead = true;
+			die();
 			// TODO check for other statuses
 		}
 	}
 
-	if ( m_isDead )
+	if ( isDead() )
 	{
 		qDebug() << m_name << " expires " << GameState::tick + Util::ticksPerDay;
 		cleanUpJob( false );
-		dropInventory();
-		dropEquipment();
 		updateSprite();
 		m_expires    = GameState::tick + Util::ticksPerDay * 2;
 		m_lastOnTick = tickNumber;
@@ -924,7 +922,7 @@ bool Gnome::evalNeeds( bool seasonChanged, bool dayChanged, bool hourChanged, bo
 				{
 					m_thoughtBubble = "";
 					cleanUpJob( false );
-					m_isDead = true;
+					die();
 					updateSprite();
 					if ( need == "Hunger" )
 					{

--- a/src/game/gnome.cpp
+++ b/src/game/gnome.cpp
@@ -721,7 +721,6 @@ CreatureTickResult Gnome::onTick( quint64 tickNumber, bool seasonChanged, bool d
 	if ( isDead() )
 	{
 		qDebug() << m_name << " expires " << GameState::tick + Util::ticksPerDay;
-		cleanUpJob( false );
 		m_expires    = GameState::tick + Util::ticksPerDay * 2;
 		m_lastOnTick = tickNumber;
 		return CreatureTickResult::DEAD;
@@ -865,6 +864,12 @@ CreatureTickResult Gnome::onTick( quint64 tickNumber, bool seasonChanged, bool d
 	return CreatureTickResult::OK;
 }
 
+void Gnome::die()
+{
+	Creature::die();
+	cleanUpJob( false );
+}
+
 bool Gnome::checkFloor()
 {
 	FloorType ft = Global::w().floorType( m_position );
@@ -920,7 +925,6 @@ bool Gnome::evalNeeds( bool seasonChanged, bool dayChanged, bool hourChanged, bo
 				if ( newVal < -100 )
 				{
 					m_thoughtBubble = "";
-					cleanUpJob( false );
 					die();
 					if ( need == "Hunger" )
 					{

--- a/src/game/gnome.cpp
+++ b/src/game/gnome.cpp
@@ -722,7 +722,6 @@ CreatureTickResult Gnome::onTick( quint64 tickNumber, bool seasonChanged, bool d
 	{
 		qDebug() << m_name << " expires " << GameState::tick + Util::ticksPerDay;
 		cleanUpJob( false );
-		updateSprite();
 		m_expires    = GameState::tick + Util::ticksPerDay * 2;
 		m_lastOnTick = tickNumber;
 		return CreatureTickResult::DEAD;
@@ -923,7 +922,6 @@ bool Gnome::evalNeeds( bool seasonChanged, bool dayChanged, bool hourChanged, bo
 					m_thoughtBubble = "";
 					cleanUpJob( false );
 					die();
-					updateSprite();
 					if ( need == "Hunger" )
 					{
 						log( "Starved to death." );

--- a/src/game/gnome.h
+++ b/src/game/gnome.h
@@ -46,6 +46,8 @@ public:
 
 	virtual CreatureTickResult onTick( quint64 tickNumber, bool seasonChanged, bool dayChanged, bool hourChanged, bool minuteChanged );
 
+	void die() override;
+
 	// return true if no floor present
 	bool checkFloor();
 

--- a/src/game/gnometrader.cpp
+++ b/src/game/gnometrader.cpp
@@ -150,8 +150,9 @@ CreatureTickResult GnomeTrader::onTick( quint64 tickNumber, bool seasonChanged, 
 		return CreatureTickResult::NOFLOOR;
 	}
 
-	if ( m_isDead )
+	if ( isDead() )
 	{
+		die();
 		m_lastOnTick = tickNumber;
 		return CreatureTickResult::DEAD;
 	}

--- a/src/game/gnometrader.cpp
+++ b/src/game/gnometrader.cpp
@@ -152,7 +152,6 @@ CreatureTickResult GnomeTrader::onTick( quint64 tickNumber, bool seasonChanged, 
 
 	if ( isDead() )
 	{
-		die();
 		m_lastOnTick = tickNumber;
 		return CreatureTickResult::DEAD;
 	}

--- a/src/game/inventory.cpp
+++ b/src/game/inventory.cpp
@@ -986,6 +986,7 @@ unsigned int Inventory::putDownItem( unsigned int id, const Position& newPos )
 		{
 			Global::w().setItemSprite( newPos, 0 );
 		}
+		gravity( newPos );
 		return id;
 	}
 	return 0;

--- a/src/game/monster.cpp
+++ b/src/game/monster.cpp
@@ -139,7 +139,7 @@ void Monster::updateSprite()
 		defBack.append( pm );
 	}
 
-	m_spriteID = Global::sf().setCreatureSprite( m_id, def, defBack, m_isDead )->uID;
+	m_spriteID = Global::sf().setCreatureSprite( m_id, def, defBack, isDead() )->uID;
 }
 
 void Monster::updateMoveSpeed()
@@ -195,7 +195,7 @@ CreatureTickResult Monster::onTick( quint64 tickNumber, bool seasonChanged, bool
 		if ( status & AS_DEAD )
 		{
 			Global::logger().log( LogType::COMBAT, "The " + m_name + " died. Bummer!", m_id );
-			m_isDead = true;
+			die();
 			// TODO check for other statuses
 		}
 	}
@@ -205,7 +205,7 @@ CreatureTickResult Monster::onTick( quint64 tickNumber, bool seasonChanged, bool
 		m_lastOnTick = tickNumber;
 		return CreatureTickResult::TODESTROY;
 	}
-	if ( m_isDead )
+	if ( isDead() )
 	{
 		m_lastOnTick = tickNumber;
 		return CreatureTickResult::DEAD;


### PR DESCRIPTION
Fixes #98 
Fixes #62 

- Go through every item in inventory > put them on the gnome's current tile > clear the inventory
- Go trhough every item in equipment > put them on the gnome's current tile > clear the equipment
- Go through every workshops > if workshop as dead gnome as owner > Set Owner id to 0

I also moved `gravity()` from `dropEquippedItem()` to `putDownItem()` as it seems like something that should happen every time an item is put on the map

#### Testing

>Give equipment to gnome
>edit save to set hunger to -500
>load save

**Before death**
![image](https://user-images.githubusercontent.com/41293484/99904770-6fc48500-2ccd-11eb-83d8-d00905eb7c81.png)


**After death**
![image](https://user-images.githubusercontent.com/41293484/99904781-7f43ce00-2ccd-11eb-8fb9-0ab7196d919e.png)
