### PR TITLE
Removing GCC compiler warnings

### DIFF
--- a/src/base/behaviortree/bt_node.cpp
+++ b/src/base/behaviortree/bt_node.cpp
@@ -59,7 +59,7 @@ void BT_Node::deserialize( QVariantMap in )
 
 	auto vcl  = in.value( "Childs" ).toList();
 	int index = 0;
-	if ( vcl.size() == m_children.size() )
+	if ( size_t( vcl.size() ) == m_children.size() )
 	{
 
 		for ( auto child : m_children )
@@ -71,7 +71,7 @@ void BT_Node::deserialize( QVariantMap in )
 	{
 		//tree changed between saving and loading, this will have undetermined results
 		// TODO throw exception or make config option to allow or deny loading this
-		if ( vcl.size() < m_children.size() )
+		if ( size_t( vcl.size() ) < m_children.size() )
 		{
 			for ( auto vcm : vcl )
 			{

--- a/src/base/behaviortree/bt_node.cpp
+++ b/src/base/behaviortree/bt_node.cpp
@@ -59,7 +59,7 @@ void BT_Node::deserialize( QVariantMap in )
 
 	auto vcl  = in.value( "Childs" ).toList();
 	int index = 0;
-	if ( size_t( vcl.size() ) == m_children.size() )
+	if ( static_cast<size_t>( vcl.size() ) == m_children.size() )
 	{
 
 		for ( auto child : m_children )
@@ -71,7 +71,7 @@ void BT_Node::deserialize( QVariantMap in )
 	{
 		//tree changed between saving and loading, this will have undetermined results
 		// TODO throw exception or make config option to allow or deny loading this
-		if ( size_t( vcl.size() ) < m_children.size() )
+		if ( static_cast<size_t>( vcl.size() ) < m_children.size() )
 		{
 			for ( auto vcm : vcl )
 			{

--- a/src/base/behaviortree/bt_nodefallback.cpp
+++ b/src/base/behaviortree/bt_nodefallback.cpp
@@ -30,7 +30,7 @@ BT_RESULT BT_NodeFallback::tick()
 {
 	m_status = BT_RESULT::RUNNING;
 
-	for ( int index = 0; index < m_children.size(); ++index )
+	for ( size_t index = 0; index < m_children.size(); ++index )
 	{
 		BT_RESULT child_status = m_children[index]->tick();
 

--- a/src/base/behaviortree/bt_nodefallbackstar.cpp
+++ b/src/base/behaviortree/bt_nodefallbackstar.cpp
@@ -30,7 +30,7 @@ BT_RESULT BT_NodeFallbackStar::tick()
 {
 	m_status = BT_RESULT::RUNNING;
 
-	while ( m_index < m_children.size() )
+	while ( size_t( m_index ) < m_children.size() )
 	{
 		BT_RESULT child_status = m_children[m_index]->tick();
 

--- a/src/base/behaviortree/bt_nodefallbackstar.cpp
+++ b/src/base/behaviortree/bt_nodefallbackstar.cpp
@@ -30,7 +30,7 @@ BT_RESULT BT_NodeFallbackStar::tick()
 {
 	m_status = BT_RESULT::RUNNING;
 
-	while ( size_t( m_index ) < m_children.size() )
+	while ( static_cast<size_t>( m_index ) < m_children.size() )
 	{
 		BT_RESULT child_status = m_children[m_index]->tick();
 

--- a/src/base/behaviortree/bt_noderepeat.cpp
+++ b/src/base/behaviortree/bt_noderepeat.cpp
@@ -59,7 +59,7 @@ void BT_NodeRepeat::deserialize( QVariantMap in )
 
 	auto vcl  = in.value( "Childs" ).toList();
 	int index = 0;
-	if ( vcl.size() == m_children.size() )
+	if ( size_t( vcl.size() ) == m_children.size() )
 	{
 
 		for ( auto child : m_children )
@@ -71,7 +71,7 @@ void BT_NodeRepeat::deserialize( QVariantMap in )
 	{
 		//tree changed between saving and loading, this will have undetermined results
 		// TODO throw exception or make config option to allow or deny loading this
-		if ( vcl.size() < m_children.size() )
+		if ( size_t( vcl.size() ) < m_children.size() )
 		{
 			for ( auto vcm : vcl )
 			{

--- a/src/base/behaviortree/bt_noderepeat.cpp
+++ b/src/base/behaviortree/bt_noderepeat.cpp
@@ -59,7 +59,7 @@ void BT_NodeRepeat::deserialize( QVariantMap in )
 
 	auto vcl  = in.value( "Childs" ).toList();
 	int index = 0;
-	if ( size_t( vcl.size() ) == m_children.size() )
+	if ( static_cast<size_t>( vcl.size() ) == m_children.size() )
 	{
 
 		for ( auto child : m_children )
@@ -71,7 +71,7 @@ void BT_NodeRepeat::deserialize( QVariantMap in )
 	{
 		//tree changed between saving and loading, this will have undetermined results
 		// TODO throw exception or make config option to allow or deny loading this
-		if ( size_t( vcl.size() ) < m_children.size() )
+		if ( static_cast<size_t>( vcl.size() ) < m_children.size() )
 		{
 			for ( auto vcm : vcl )
 			{

--- a/src/base/behaviortree/bt_noderepeatuntilsuccess.cpp
+++ b/src/base/behaviortree/bt_noderepeatuntilsuccess.cpp
@@ -59,7 +59,7 @@ void BT_NodeRepeatUntilSuccess::deserialize( QVariantMap in )
 
 	auto vcl  = in.value( "Childs" ).toList();
 	int index = 0;
-	if ( size_t( vcl.size() ) == m_children.size() )
+	if ( static_cast<size_t>( vcl.size() ) == m_children.size() )
 	{
 
 		for ( auto child : m_children )
@@ -71,7 +71,7 @@ void BT_NodeRepeatUntilSuccess::deserialize( QVariantMap in )
 	{
 		//tree changed between saving and loading, this will have undetermined results
 		// TODO throw exception or make config option to allow or deny loading this
-		if ( size_t( vcl.size() ) < m_children.size() )
+		if ( static_cast<size_t>( vcl.size() ) < m_children.size() )
 		{
 			for ( auto vcm : vcl )
 			{

--- a/src/base/behaviortree/bt_noderepeatuntilsuccess.cpp
+++ b/src/base/behaviortree/bt_noderepeatuntilsuccess.cpp
@@ -59,7 +59,7 @@ void BT_NodeRepeatUntilSuccess::deserialize( QVariantMap in )
 
 	auto vcl  = in.value( "Childs" ).toList();
 	int index = 0;
-	if ( vcl.size() == m_children.size() )
+	if ( size_t( vcl.size() ) == m_children.size() )
 	{
 
 		for ( auto child : m_children )
@@ -71,7 +71,7 @@ void BT_NodeRepeatUntilSuccess::deserialize( QVariantMap in )
 	{
 		//tree changed between saving and loading, this will have undetermined results
 		// TODO throw exception or make config option to allow or deny loading this
-		if ( vcl.size() < m_children.size() )
+		if ( size_t( vcl.size() ) < m_children.size() )
 		{
 			for ( auto vcm : vcl )
 			{

--- a/src/base/behaviortree/bt_nodesequence.cpp
+++ b/src/base/behaviortree/bt_nodesequence.cpp
@@ -30,7 +30,7 @@ BT_RESULT BT_NodeSequence::tick()
 {
 	m_status = BT_RESULT::RUNNING;
 
-	for ( int index = 0; index < m_children.size(); ++index )
+	for ( size_t index = 0; index < m_children.size(); ++index )
 	{
 		BT_RESULT child_status = m_children[index]->tick();
 

--- a/src/base/behaviortree/bt_nodesequencestar.cpp
+++ b/src/base/behaviortree/bt_nodesequencestar.cpp
@@ -59,7 +59,7 @@ void BT_NodeSequenceStar::deserialize( QVariantMap in )
 
 	auto vcl  = in.value( "Childs" ).toList();
 	int index = 0;
-	if ( size_t( vcl.size() ) == m_children.size() )
+	if ( static_cast<size_t>( vcl.size() ) == m_children.size() )
 	{
 
 		for ( auto child : m_children )
@@ -71,7 +71,7 @@ void BT_NodeSequenceStar::deserialize( QVariantMap in )
 	{
 		//tree changed between saving and loading, this will have undetermined results
 		// TODO throw exception or make config option to allow or deny loading this
-		if ( size_t( vcl.size() ) < m_children.size() )
+		if ( static_cast<size_t>( vcl.size() ) < m_children.size() )
 		{
 			for ( auto vcm : vcl )
 			{
@@ -92,7 +92,7 @@ BT_RESULT BT_NodeSequenceStar::tick()
 {
 	m_status = BT_RESULT::RUNNING;
 
-	while ( size_t( m_index ) < m_children.size() )
+	while ( static_cast<size_t>( m_index ) < m_children.size() )
 	{
 		BT_RESULT child_status = m_children[m_index]->tick();
 

--- a/src/base/behaviortree/bt_nodesequencestar.cpp
+++ b/src/base/behaviortree/bt_nodesequencestar.cpp
@@ -59,7 +59,7 @@ void BT_NodeSequenceStar::deserialize( QVariantMap in )
 
 	auto vcl  = in.value( "Childs" ).toList();
 	int index = 0;
-	if ( vcl.size() == m_children.size() )
+	if ( size_t( vcl.size() ) == m_children.size() )
 	{
 
 		for ( auto child : m_children )
@@ -71,7 +71,7 @@ void BT_NodeSequenceStar::deserialize( QVariantMap in )
 	{
 		//tree changed between saving and loading, this will have undetermined results
 		// TODO throw exception or make config option to allow or deny loading this
-		if ( vcl.size() < m_children.size() )
+		if ( size_t( vcl.size() ) < m_children.size() )
 		{
 			for ( auto vcm : vcl )
 			{
@@ -92,7 +92,7 @@ BT_RESULT BT_NodeSequenceStar::tick()
 {
 	m_status = BT_RESULT::RUNNING;
 
-	while ( m_index < m_children.size() )
+	while ( size_t( m_index ) < m_children.size() )
 	{
 		BT_RESULT child_status = m_children[m_index]->tick();
 

--- a/src/base/io.cpp
+++ b/src/base/io.cpp
@@ -195,7 +195,7 @@ QString IO::save( bool autosave )
 	}
 	int slot = 0;
 
-	if( autosave )
+	if ( autosave )
 	{
 		folder += "autosave";
 
@@ -210,7 +210,7 @@ QString IO::save( bool autosave )
 	}
 	else
 	{
-	
+
 		QDirIterator directories( folder, QDir::Dirs | QDir::NoDotAndDotDot );
 		QStringList dirs;
 		while ( directories.hasNext() )
@@ -423,9 +423,9 @@ void IO::sanitize()
 				}
 			}
 		}
-		for( auto& ws : Global::wsm().workshops() )
+		for ( auto& ws : Global::wsm().workshops() )
 		{
-			for( auto& vitem : ws->sourceItems() )
+			for ( auto& vitem : ws->sourceItems() )
 			{
 				Global::inv().pickUpItem( vitem.toUInt() );
 			}

--- a/src/base/modmanager.cpp
+++ b/src/base/modmanager.cpp
@@ -106,7 +106,6 @@ void ModManager::loadMod( QJsonObject jo )
 
 	bool isTranslation = ( type == "Translation" );
 
-	
 	QJsonDocument jd;
 	IO::loadFile( folder + "/files.json", jd );
 

--- a/src/base/regionmap.cpp
+++ b/src/base/regionmap.cpp
@@ -812,7 +812,6 @@ bool RegionMap::checkConnectedRegions( const Position& start, const Position& go
 	return checkConnectedRegions( regionID( start ), regionID( goal ) );
 }
 
-
 std::vector<Position> RegionMap::connectedNeighborsUp( const Position& pos )
 {
 	std::vector<Position> out;

--- a/src/base/regionmap.cpp
+++ b/src/base/regionmap.cpp
@@ -78,7 +78,7 @@ void RegionMap::initRegions()
 	m_regions.emplace_back( 0 );
 	m_regionMap.clear();
 	m_regionMap.resize( world.world().size() );
-	for ( auto i = 0; i < m_regionMap.size(); ++i )
+	for ( size_t i = 0; i < m_regionMap.size(); ++i )
 		m_regionMap[i] = 0;
 
 	QElapsedTimer timer;

--- a/src/base/util.cpp
+++ b/src/base/util.cpp
@@ -811,7 +811,7 @@ QString Util::addDyeMaterial( QString sourceMaterial, QString dyeMaterial )
 		Strings::getInstance().insertString( "$MaterialName_" + targetMaterial, S::s( "$MaterialName_" + dyeMaterial ) + " " + S::s( "$MaterialName_" + sourceMaterial ) );
 
 		GameState::addedMaterials.append( sourceRow );
-		
+
 		GameState::addedTranslations.insert( "$MaterialName_" + targetMaterial, S::s( "$MaterialName_" + dyeMaterial ) + " " + S::s( "$MaterialName_" + sourceMaterial ) );
 	}
 	return targetMaterial;
@@ -910,7 +910,7 @@ QPixmap Util::createItemImage( const QString& itemID, const QStringList& mats )
 QPixmap Util::createItemImage2( const QString& itemID, const QStringList& mats )
 {
 	auto spriteID = DB::select( "SpriteID", "Items", itemID ).toString();
-	
+
 	QString season = GameState::seasonString;
 
 	SpriteFactory& sf = Global::sf();
@@ -922,7 +922,7 @@ QPixmap Util::createItemImage2( const QString& itemID, const QStringList& mats )
 	int x0 = 0;
 	int y0 = 0;
 
-	Sprite* sprite = sf.createSprite( spriteID, mats ) ;
+	Sprite* sprite = sf.createSprite( spriteID, mats );
 	if ( sprite )
 	{
 		//painter.drawPixmap( px + sprite->xOffset, py + sprite->yOffset, sprite->pixmap( season, rot ) );

--- a/src/game/animal.cpp
+++ b/src/game/animal.cpp
@@ -44,7 +44,7 @@ Animal::Animal( QString species, Position& pos, Gender gender, bool adult ) :
 	m_aquatic  = avm.value( "Aquatic" ).toBool();
 	m_btName   = avm.value( "BehaviorTree" ).toString();
 	m_preyList = avm.value( "Prey" ).toString().split( "|" );
-	
+
 	m_isMulti = avm.value( "IsMulti" ).toBool();
 
 	int hungerRand = ( rand() % 20 ) - 10;
@@ -90,7 +90,7 @@ Animal::Animal( QVariantMap in ) :
 
 	m_aquatic  = avm.value( "Aquatic" ).toBool();
 	m_preyList = avm.value( "Prey" ).toString().split( "|" );
-	
+
 	m_hunger = qMax( -10.f, in.value( "Hunger" ).toFloat() );
 
 	QVariantMap m_stateMap;
@@ -231,8 +231,8 @@ void Animal::updateSprite()
 		}
 		if ( sprite )
 		{
-			m_hasTransparency  = sprite->hasTransp;
-			m_spriteID = sprite->uID;
+			m_hasTransparency = sprite->hasTransp;
+			m_spriteID        = sprite->uID;
 		}
 		else
 		{
@@ -1168,7 +1168,7 @@ BT_RESULT Animal::actionAttackTarget( bool halt )
 	{
 		creature = Global::cm().creature( m_currentAttackTarget );
 	}
-	
+
 	if ( creature && !creature->isDead() )
 	{
 		m_facing = getFacing( m_position, creature->getPos() );
@@ -1304,7 +1304,7 @@ bool Animal::toButcher()
 {
 	return m_toButcher;
 }
-	
+
 void Animal::setToButcher( bool value )
 {
 	m_toButcher = value;

--- a/src/game/animal.h
+++ b/src/game/animal.h
@@ -135,7 +135,6 @@ private:
 
 	void checkInJob();
 
-
 	bool m_isMulti = false;
 	bool m_tame    = false;
 

--- a/src/game/canwork.cpp
+++ b/src/game/canwork.cpp
@@ -42,11 +42,12 @@
 
 //#include "../gui/strings.h"
 
-#include <exprtk.hpp>
 #include "../gfx/sprite.h"
 #include "../gfx/spritefactory.h"
 
 #include <QDebug>
+
+#include <exprtk.hpp>
 
 typedef exprtk::symbol_table<double> symbol_table_t;
 typedef exprtk::expression<double> expression_t;
@@ -314,7 +315,7 @@ void CanWork::cleanUpJob( bool finished )
 			}
 		}
 	}
-	if( m_btBlackBoard.contains( "ClaimedUniformItem" ) )
+	if ( m_btBlackBoard.contains( "ClaimedUniformItem" ) )
 	{
 		auto itemID = m_btBlackBoard.value( "ClaimedUniformItem" ).toUInt();
 		inv.setInJob( itemID, 0 );
@@ -732,7 +733,7 @@ bool CanWork::explorativeMineWall()
 		};
 		for ( const auto& candidate : candidates )
 		{
-			if ( world.getTile(candidate).embeddedMaterial == mats.second )
+			if ( world.getTile( candidate ).embeddedMaterial == mats.second )
 			{
 				Global::jm().addJob( "ExplorativeMine", candidate, 0 );
 			}

--- a/src/game/creature.cpp
+++ b/src/game/creature.cpp
@@ -185,10 +185,10 @@ void Creature::serialize( QVariantMap& out ) const
 	out.insert( "Orientation", m_facing );
 	//unsigned int m_followID = 0;
 	out.insert( "FollowID", m_followID ),
-	//Position m_followPosition;
-	out.insert( "FollowPosition", m_followPosition.toString() ),
-	//Gender m_gender = UNDEFINED;
-	out.insert( "Gender", (unsigned char)m_gender );
+		//Position m_followPosition;
+		out.insert( "FollowPosition", m_followPosition.toString() ),
+		//Gender m_gender = UNDEFINED;
+		out.insert( "Gender", (unsigned char)m_gender );
 	//QString m_name = "not_initialized";
 	out.insert( "Name", m_name );
 	//bool m_immobile = false;
@@ -714,20 +714,20 @@ void Creature::move( Position oldPos )
 		Global::w().removeCreatureFromPosition( oldPos, m_id );
 		Global::w().insertCreatureAtPosition( m_position, m_id );
 
-		if( m_hasTransparency )
+		if ( m_hasTransparency )
 		{
 			Global::w().setTileFlag( m_position, TileFlag::TF_TRANSPARENT );
 			// check if no other creatures with transparency on tile
 			bool transp = false;
-			for( auto c : Global::cm().creaturesAtPosition( oldPos ) )
+			for ( auto c : Global::cm().creaturesAtPosition( oldPos ) )
 			{
-				if( c->hasTransparency() )
+				if ( c->hasTransparency() )
 				{
 					transp = true;
 					break;
 				}
 			}
-			if( !transp )
+			if ( !transp )
 			{
 				Global::w().clearTileFlag( oldPos, TileFlag::TF_TRANSPARENT );
 			}
@@ -838,7 +838,7 @@ bool Creature::kill( bool nocorpse )
 	if ( !toDestroy() && !isDead() )
 	{
 		//kill succeeds
-		if( nocorpse )
+		if ( nocorpse )
 		{
 			destroy();
 		}
@@ -897,7 +897,7 @@ BT_RESULT Creature::conditionTargetPositionValid( bool halt )
 	{
 		creature = resolveTarget( m_currentAttackTarget );
 	}
-	if (creature)
+	if ( creature )
 	{
 		if ( creature->getPos() == m_currentTargetPosition )
 		{
@@ -1050,7 +1050,7 @@ void Creature::die()
 
 void Creature::dropInventory()
 {
-	Inventory &inv = Global::inv();
+	Inventory& inv = Global::inv();
 	for ( const unsigned int it : inventoryItems() )
 	{
 		inv.putDownItem( it, m_position );

--- a/src/game/creature.h
+++ b/src/game/creature.h
@@ -272,10 +272,19 @@ public:
 		return m_claimedItems;
 	}
 
-	bool isAnimal() { return m_type == CreatureType::ANIMAL; }
-	bool isMonster() { return m_type == CreatureType::MONSTER; }
+	bool isAnimal()
+	{
+		return m_type == CreatureType::ANIMAL;
+	}
+	bool isMonster()
+	{
+		return m_type == CreatureType::MONSTER;
+	}
 
-	bool hasTransparency() { return m_hasTransparency; }
+	bool hasTransparency()
+	{
+		return m_hasTransparency;
+	}
 
 protected:
 	virtual void loadBehaviorTree( QString id ) final;
@@ -328,7 +337,7 @@ protected:
 	qint8 m_facingAfterMove = -1;
 
 	unsigned int m_currentAttackTarget = 0;
-	bool m_goneOffMap = false;
+	bool m_goneOffMap                  = false;
 
 	QVariantMap m_btBlackBoard;
 

--- a/src/game/creaturemanager.cpp
+++ b/src/game/creaturemanager.cpp
@@ -20,12 +20,12 @@
 #include "../base/db.h"
 #include "../base/global.h"
 #include "../base/regionmap.h"
-#include "../game/world.h"
 #include "../game/creaturefactory.h"
 #include "../game/farmingmanager.h"
 #include "../game/inventory.h"
 #include "../game/jobmanager.h"
 #include "../game/newgamesettings.h"
+#include "../game/world.h"
 
 #include <QDebug>
 #include <QElapsedTimer>
@@ -48,7 +48,7 @@ void CreatureManager::reset()
 
 	// add monster entries for monsters that aren't typically on the map so they can appear in the squad priority list
 	auto monsters = DB::ids( "Monsters" );
-	for( auto monster : monsters )
+	for ( auto monster : monsters )
 	{
 		m_countPerType.insert( monster, 0 );
 	}
@@ -61,7 +61,6 @@ void CreatureManager::reset()
 			m_countPerType.insert( animal, 0 );
 		}
 	}
-
 }
 
 void CreatureManager::onTick( quint64 tickNumber, bool seasonChanged, bool dayChanged, bool hourChanged, bool minuteChanged )
@@ -87,7 +86,7 @@ void CreatureManager::onTick( quint64 tickNumber, bool seasonChanged, bool dayCh
 				toDestroy.append( creature->id() );
 				break;
 			case CreatureTickResult::DEAD:
-				if( creature->type() == CreatureType::ANIMAL )
+				if ( creature->type() == CreatureType::ANIMAL )
 				{
 					auto a = dynamic_cast<Animal*>( creature );
 					Global::inv().createItem( a->getPos(), "AnimalCorpse", { a->species() } );
@@ -119,7 +118,6 @@ void CreatureManager::onTick( quint64 tickNumber, bool seasonChanged, bool dayCh
 
 	if ( hourChanged )
 	{
-		
 	}
 }
 
@@ -150,7 +148,7 @@ QList<Animal*> CreatureManager::animalsAtPosition( Position& pos )
 	}
 	return out;
 }
-	
+
 QList<Monster*> CreatureManager::monstersAtPosition( Position& pos )
 {
 	QList<Monster*> out;
@@ -186,14 +184,14 @@ unsigned int CreatureManager::addCreature( CreatureType ct, QString type, Positi
 			break;
 	}
 
-	if( creature )
+	if ( creature )
 	{
 		m_creatures.append( creature );
 		unsigned int id = m_creatures.last()->id();
 		m_creaturesByID.insert( id, m_creatures.last() );
 
 		int count = m_countPerType.value( type );
-	
+
 		++count;
 		m_countPerType.insert( type, count );
 
@@ -202,7 +200,7 @@ unsigned int CreatureManager::addCreature( CreatureType ct, QString type, Positi
 
 		m_dirty = true;
 
-		if( creature->hasTransparency() )
+		if ( creature->hasTransparency() )
 		{
 			Global::w().setTileFlag( creature->getPos(), TileFlag::TF_TRANSPARENT );
 		}
@@ -224,7 +222,7 @@ unsigned int CreatureManager::addCreature( CreatureType ct, QVariantMap vals )
 			creature = CreatureFactory::getInstance().createMonster( vals );
 			break;
 	}
-	if( creature )
+	if ( creature )
 	{
 		m_creatures.append( creature );
 		unsigned int id = m_creatures.last()->id();
@@ -240,7 +238,7 @@ unsigned int CreatureManager::addCreature( CreatureType ct, QVariantMap vals )
 
 		m_dirty = true;
 
-		if( creature->hasTransparency() )
+		if ( creature->hasTransparency() )
 		{
 			Global::w().setTileFlag( creature->getPos(), TileFlag::TF_TRANSPARENT );
 		}
@@ -264,20 +262,20 @@ Animal* CreatureManager::animal( unsigned int id )
 	if ( m_creaturesByID.contains( id ) )
 	{
 		auto c = m_creaturesByID[id];
-		if( c->isAnimal() )
+		if ( c->isAnimal() )
 		{
 			return dynamic_cast<Animal*>( c );
 		}
 	}
 	return nullptr;
 }
-	
+
 Monster* CreatureManager::monster( unsigned int id )
 {
 	if ( m_creaturesByID.contains( id ) )
 	{
 		auto c = m_creaturesByID[id];
-		if( c->isMonster() )
+		if ( c->isMonster() )
 		{
 			return dynamic_cast<Monster*>( c );
 		}
@@ -299,11 +297,11 @@ int CreatureManager::count( QString type )
 
 void CreatureManager::removeCreature( unsigned int id )
 {
-	if( m_creaturesByID.contains( id ) )
+	if ( m_creaturesByID.contains( id ) )
 	{
 		auto creature = m_creaturesByID[id];
 
-		switch( creature->type() )
+		switch ( creature->type() )
 		{
 			case CreatureType::ANIMAL:
 			{
@@ -360,7 +358,7 @@ PriorityQueue<Animal*, int> CreatureManager::animalsByDistance( Position pos, QS
 	for ( auto id : m_creaturesPerType[type] )
 	{
 		Creature* creature = m_creaturesByID[id];
-		if( creature->isAnimal() )
+		if ( creature->isAnimal() )
 		{
 			Animal* a = dynamic_cast<Animal*>( creature );
 			if ( a && !a->inJob() && !a->isDead() && !a->toDestroy() )
@@ -401,10 +399,9 @@ QList<QString> CreatureManager::types()
 	return m_countPerType.keys();
 }
 
-	
 QList<Animal*>& CreatureManager::animals()
 {
-	if( m_dirty )
+	if ( m_dirty )
 	{
 		updateLists();
 	}
@@ -414,7 +411,7 @@ QList<Animal*>& CreatureManager::animals()
 
 QList<Monster*>& CreatureManager::monsters()
 {
-	if( m_dirty )
+	if ( m_dirty )
 	{
 		updateLists();
 	}
@@ -427,9 +424,9 @@ void CreatureManager::updateLists()
 	m_animals.clear();
 	m_monsters.clear();
 
-	for( auto c : m_creatures )
+	for ( auto c : m_creatures )
 	{
-		if( c->isAnimal() )
+		if ( c->isAnimal() )
 		{
 			m_animals.append( dynamic_cast<Animal*>( c ) );
 		}
@@ -443,10 +440,10 @@ void CreatureManager::updateLists()
 
 bool CreatureManager::hasPathTo( Position& pos, unsigned int creatureID )
 {
-	if( m_creaturesByID.contains( creatureID ) )
+	if ( m_creaturesByID.contains( creatureID ) )
 	{
 		auto creature = m_creaturesByID[creatureID];
-		if( creature )
+		if ( creature )
 		{
 			return Global::w().regionMap().checkConnectedRegions( pos, creature->getPos() );
 		}

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -43,9 +43,9 @@
 #include "../game/workshopmanager.h"
 #include "../game/world.h"
 #include "../gfx/spritefactory.h"
+#include "../gui/aggregatorcreatureinfo.h"
 #include "../gui/eventconnector.h"
 #include "../gui/strings.h"
-#include "../gui/aggregatorcreatureinfo.h"
 
 #include <QDebug>
 #include <QElapsedTimer>
@@ -62,22 +62,22 @@ Game::Game()
 	m_millisecondsSlow = DB::select( "Value_", "Time", "MillisecondsSlow" ).toInt();
 	m_millisecondsFast = DB::select( "Value_", "Time", "MillisecondsFast" ).toInt();
 
-	GameState::tick = 1;
-	GameState::hour = 9;
+	GameState::tick   = 1;
+	GameState::hour   = 9;
 	GameState::minute = 0;
 	GameState::day    = 1;
 	GameState::season = 0; // zero based, 0-numSeasons, typically 4 can be modded
 	GameState::year   = 1;
 
-	QString dt = QString( "Day %1, %2:%3" ).arg( GameState::day, 2, 10, QChar( ' ' ) ).arg( GameState::hour, 2, 10, QChar( '0' ) ).arg( GameState::minute, 2, 10, QChar( '0' ) );
-	GameState::currentDayTime = dt;
-	GameState::seasonString = "Spring";
+	QString dt                      = QString( "Day %1, %2:%3" ).arg( GameState::day, 2, 10, QChar( ' ' ) ).arg( GameState::hour, 2, 10, QChar( '0' ) ).arg( GameState::minute, 2, 10, QChar( '0' ) );
+	GameState::currentDayTime       = dt;
+	GameState::seasonString         = "Spring";
 	GameState::currentYearAndSeason = "Year " + QString::number( GameState::year ) + ", " + S::s( "$SeasonName_" + GameState::seasonString );
 
 	calcDaylight();
 	GameState::daylight = true;
 
-	for( auto t : DB::ids( "Tech" ) )
+	for ( auto t : DB::ids( "Tech" ) )
 	{
 		GameState::techs.insert( t, 1 );
 	}
@@ -110,7 +110,6 @@ Game::Game( bool isLoaded )
 
 	Global::xpMod = Config::getInstance().get( "XpMod" ).toDouble();
 }
-
 
 Game::~Game()
 {
@@ -270,8 +269,8 @@ void Game::sendClock()
 		{
 			GameState::day = 1;
 			++GameState::season;
-			GameState::seasonChanged    = true;
-			QString nextSeason = DB::select( "NextSeason", "Seasons", GameState::seasonString ).toString();
+			GameState::seasonChanged = true;
+			QString nextSeason       = DB::select( "NextSeason", "Seasons", GameState::seasonString ).toString();
 			//qDebug() << "Now it's " << nextSeason;
 			GameState::seasonString = nextSeason;
 
@@ -299,23 +298,23 @@ void Game::sendClock()
 	if ( currentTimeInt < GameState::sunrise )
 	{
 		//time between midnight and sunrise
-		sunStatus        = "Sunrise: " + intToTime( GameState::sunrise );
+		sunStatus           = "Sunrise: " + intToTime( GameState::sunrise );
 		GameState::daylight = false;
 	}
 	else if ( currentTimeInt < GameState::sunset )
 	{
 		// day time
-		sunStatus        = "Sunset: " + intToTime( GameState::sunset );
+		sunStatus           = "Sunset: " + intToTime( GameState::sunset );
 		GameState::daylight = true;
 	}
 	else
 	{
 		// time after sunset
-		sunStatus        = "Sunrise: " + intToTime( GameState::nextSunrise );
+		sunStatus           = "Sunrise: " + intToTime( GameState::nextSunrise );
 		GameState::daylight = false;
 	}
-	QString dt = QString( "Day %1, %2:%3" ).arg( GameState::day, 2, 10, QChar( ' ' ) ).arg( GameState::hour, 2, 10, QChar( '0' ) ).arg( GameState::minute, 2, 10, QChar( '0' ) );
-	GameState::currentDayTime = dt;
+	QString dt                      = QString( "Day %1, %2:%3" ).arg( GameState::day, 2, 10, QChar( ' ' ) ).arg( GameState::hour, 2, 10, QChar( '0' ) ).arg( GameState::minute, 2, 10, QChar( '0' ) );
+	GameState::currentDayTime       = dt;
 	GameState::currentYearAndSeason = "Year " + QString::number( GameState::year ) + ", " + S::s( "$SeasonName_" + GameState::seasonString );
 	emit signalTimeAndDate( GameState::minute, GameState::hour, GameState::day, S::s( "$SeasonName_" + GameState::seasonString ), GameState::year, sunStatus );
 }

--- a/src/game/gamemanager.cpp
+++ b/src/game/gamemanager.cpp
@@ -80,7 +80,7 @@ void GameManager::startNewGame( std::function<void( void )> callback )
 
 	// save current settings for fast create new game
 	NewGameSettings::getInstance().save();
-	
+
 	// check if folder exists, set new save folder name if yes
 	createNewGame();
 	callback();
@@ -221,7 +221,7 @@ void GameManager::createNewGame()
 	Util::initAllowedInContainer();
 
 	Config::getInstance().set( "NoRender", false );
-	
+
 	EventConnector::getInstance().onViewLevel( Config::getInstance().get( "viewLevel" ).toInt() );
 	m_game->moveToThread( &m_gameThread );
 
@@ -267,7 +267,7 @@ GameSpeed GameManager::gameSpeed()
 void GameManager::setGameSpeed( GameSpeed speed )
 {
 	qDebug() << (int)speed;
-	if( m_gameSpeed != speed )
+	if ( m_gameSpeed != speed )
 	{
 		m_gameSpeed = speed;
 		emit signalUpdateGameSpeed( m_gameSpeed );
@@ -285,7 +285,7 @@ void GameManager::trySetPaused( bool value )
 
 void GameManager::setPaused( bool value )
 {
-	if( m_paused != value )
+	if ( m_paused != value )
 	{
 		m_paused = value;
 		emit signalUpdatePaused( value );

--- a/src/game/gnome.cpp
+++ b/src/game/gnome.cpp
@@ -28,9 +28,9 @@
 #include "../game/militarymanager.h"
 #include "../game/plant.h"
 #include "../game/stockpilemanager.h"
-#include "../game/world.h"
 #include "../game/workshop.h"
 #include "../game/workshopmanager.h"
+#include "../game/world.h"
 #include "../gfx/spritefactory.h"
 #include "../gui/strings.h"
 
@@ -97,13 +97,16 @@ Gnome::Gnome( QVariantMap& in ) :
 	{
 		auto list = in.value( "Schedule" ).toList();
 		m_schedule.clear();
-		for( auto vs : list )
+		for ( auto vs : list )
 		{
-			auto ss = vs.toString();
+			auto ss             = vs.toString();
 			ScheduleActivity sa = ScheduleActivity::None;
-			if ( ss == "eat" ) sa = ScheduleActivity::Eat;
-			else if ( ss == "sleep" ) sa = ScheduleActivity::Sleep;
-			else if ( ss == "train" ) sa = ScheduleActivity::Training;
+			if ( ss == "eat" )
+				sa = ScheduleActivity::Eat;
+			else if ( ss == "sleep" )
+				sa = ScheduleActivity::Sleep;
+			else if ( ss == "train" )
+				sa = ScheduleActivity::Training;
 
 			m_schedule.append( sa );
 		}
@@ -160,10 +163,8 @@ void Gnome::serialize( QVariantMap& out )
 
 	out.insert( "Profession", m_profession );
 
-	
-
 	QVariantList vSchedule;
-	for( auto sa : m_schedule )
+	for ( auto sa : m_schedule )
 	{
 		switch ( sa )
 		{

--- a/src/game/gnomeactions.cpp
+++ b/src/game/gnomeactions.cpp
@@ -1157,11 +1157,9 @@ BT_RESULT Gnome::actionEquipTool( bool halt )
 	return BT_RESULT::FAILURE;
 }
 
-
-
 bool Gnome::checkUniformItem( QString slot, Uniform* uniform, bool& dropped )
 {
-	if( m_jobID )
+	if ( m_jobID )
 	{
 		return false;
 	}
@@ -1280,19 +1278,19 @@ bool Gnome::checkUniformItem( QString slot, Uniform* uniform, bool& dropped )
 		if ( itemToGet )
 		{
 			auto pos = Global::inv().getItemPos( itemToGet );
-			
+
 			m_btBlackBoard.insert( "ClaimedUniformItem", itemToGet );
 			m_btBlackBoard.insert( "ClaimedUniformItemSlot", slot );
-			
+
 			auto& jm = Global::jm();
-			
+
 			m_jobID = jm.addJob( "EquipItem", pos, 0, true );
-			
+
 			if ( m_jobID != 0 )
 			{
 				m_jobChanged = true;
 				m_job        = jm.getJob( m_jobID );
-				if( m_job )
+				if ( m_job )
 				{
 					Global::inv().setInJob( itemToGet, m_jobID );
 					//no change to jobsprite
@@ -2279,10 +2277,10 @@ BT_RESULT Gnome::actionGetTarget( bool halt )
 		log( "actionGetTarget" );
 
 	// Unset current attack target if invalidated
-	if (m_currentAttackTarget)
+	if ( m_currentAttackTarget )
 	{
 		const Creature* creature = Global::cm().creature( m_currentAttackTarget );
-		if (!creature || creature->isDead() || !Global::cm().hasPathTo(m_position, creature->id()))
+		if ( !creature || creature->isDead() || !Global::cm().hasPathTo( m_position, creature->id() ) )
 		{
 			m_currentAttackTarget = 0;
 			m_thoughtBubble       = "";
@@ -2312,8 +2310,8 @@ BT_RESULT Gnome::actionGetTarget( bool halt )
 					if ( creature && Global::cm().hasPathTo( m_position, creature->id() ) )
 					{
 						const unsigned int dist = m_position.distSquare( creature->getPos() );
-						bestDistance    = dist;
-						bestCandidate   = creature;
+						bestDistance            = dist;
+						bestCandidate           = creature;
 						// Any legal match is a good hit
 						break;
 					}
@@ -2590,16 +2588,16 @@ bool Gnome::equipItem()
 			Global::inv().setInJob( itemSlot.itemID, 0 );
 			Global::inv().setConstructedOrEquipped( itemSlot.itemID, false );
 		}
-		itemSlot.itemID = itemID;
-		itemSlot.item   = itemSID;
+		itemSlot.itemID     = itemID;
+		itemSlot.item       = itemSID;
 		itemSlot.materialID = materialUID;
 		itemSlot.material   = materialSID;
-		if (part == CP_LEFT_HAND_HELD)
+		if ( part == CP_LEFT_HAND_HELD )
 		{
 			equipHand( itemID, "Left" );
 			itemSlot.allMats = Global::inv().allMats( itemID );
 		}
-		else if (part == CP_RIGHT_HAND_HELD )
+		else if ( part == CP_RIGHT_HAND_HELD )
 		{
 			equipHand( itemID, "Right" );
 			itemSlot.allMats = Global::inv().allMats( itemID );
@@ -2612,7 +2610,6 @@ bool Gnome::equipItem()
 		m_renderParamsChanged = true;
 		return true;
 	}
-
 
 	return false;
 }

--- a/src/game/gnomemanager.cpp
+++ b/src/game/gnomemanager.cpp
@@ -66,9 +66,9 @@ void GnomeManager::clear()
 
 bool GnomeManager::contains( unsigned int gnomeID )
 {
-	for( auto gnome : m_gnomes )
+	for ( auto gnome : m_gnomes )
 	{
-		if( gnome->id() == gnomeID )
+		if ( gnome->id() == gnomeID )
 		{
 			return true;
 		}
@@ -449,8 +449,8 @@ QStringList GnomeManager::professionSkills( QString profession )
 QString GnomeManager::addProfession()
 {
 	QString name = "NewProfession";
-	
-	if( !m_profs.contains( name ) )
+
+	if ( !m_profs.contains( name ) )
 	{
 		m_profs.insert( name, QStringList() );
 		saveProfessions();
@@ -458,7 +458,7 @@ QString GnomeManager::addProfession()
 	}
 	int suffixNumber = 1;
 
-	while( m_profs.contains( name + QString::number( suffixNumber ) ) )
+	while ( m_profs.contains( name + QString::number( suffixNumber ) ) )
 	{
 		++suffixNumber;
 	}
@@ -670,7 +670,7 @@ unsigned int GnomeManager::roleID( unsigned int gnomeID )
 	}
 	return 0;
 }
-	
+
 void GnomeManager::setRoleID( unsigned int gnomeID, unsigned int roleID )
 {
 	if ( m_gnomesByID.contains( gnomeID ) )

--- a/src/game/inventory.cpp
+++ b/src/game/inventory.cpp
@@ -192,7 +192,7 @@ Item* Inventory::getItem( unsigned int itemUID )
 	auto it = m_items.find( itemUID );
 	if ( it != m_items.end() )
 	{
-		return &(*it);
+		return &( *it );
 	}
 	return nullptr;
 }
@@ -1729,7 +1729,7 @@ void Inventory::gravity( Position pos )
 		{
 			Position newPos = pos;
 			Global::w().getFloorLevelBelow( newPos, false );
-			if( newPos == pos )
+			if ( newPos == pos )
 			{
 				return;
 			}
@@ -1907,9 +1907,9 @@ QList<QString> Inventory::allMats( unsigned int itemID )
 		QStringList out;
 
 		auto comps = item->components();
-		if( comps.size() )
+		if ( comps.size() )
 		{
-			for( const auto& comp : comps )
+			for ( const auto& comp : comps )
 			{
 				out.append( DBH::materialSID( comp.materialUID ) );
 			}
@@ -1918,7 +1918,6 @@ QList<QString> Inventory::allMats( unsigned int itemID )
 		{
 			out.append( item->materialSID() );
 		}
-
 
 		return out;
 	}

--- a/src/game/item.cpp
+++ b/src/game/item.cpp
@@ -22,7 +22,6 @@
 #include "../base/util.h"
 #include "../gfx/spritefactory.h"
 #include "../gui/strings.h"
-
 #include "jobmanager.h"
 
 #include <QDebug>
@@ -63,16 +62,16 @@ Item::Item( QVariantMap in ) :
 	m_position = Position( in.value( "Position" ).toString() );
 	m_spriteID = in.value( "SpriteID" ).toUInt();
 	*/
-	m_itemUID       = DBH::itemUID( in.value( "ItemSID" ).toString() );
-	m_materialUID   = DBH::materialUID( in.value( "MaterialSID" ).toString() );
-	m_isInStockpile = in.value( "InStockpile" ).toUInt();
-	m_isInJob       = in.value( "InJob" ).toUInt();
-	m_isInContainer = in.value( "InContainer" ).toUInt();
+	m_itemUID                 = DBH::itemUID( in.value( "ItemSID" ).toString() );
+	m_materialUID             = DBH::materialUID( in.value( "MaterialSID" ).toString() );
+	m_isInStockpile           = in.value( "InStockpile" ).toUInt();
+	m_isInJob                 = in.value( "InJob" ).toUInt();
+	m_isInContainer           = in.value( "InContainer" ).toUInt();
 	m_isConstructedOrEquipped = in.value( "Constructed" ).toBool();
-	m_isPickedUp    = in.value( "IsPickedUp" ).toBool();
-	m_value         = in.value( "Value" ).toUInt();
-	m_madeBy        = in.value( "MadeBy" ).toUInt();
-	m_quality       = in.value( "Quality" ).toUInt();
+	m_isPickedUp              = in.value( "IsPickedUp" ).toBool();
+	m_value                   = in.value( "Value" ).toUInt();
+	m_madeBy                  = in.value( "MadeBy" ).toUInt();
+	m_quality                 = in.value( "Quality" ).toUInt();
 
 	if ( in.value( "Extra" ).toBool() )
 	{
@@ -357,7 +356,7 @@ QList<ItemMaterial> Item::components() const
 
 unsigned short Item::value() const
 {
-	return m_value * DBH::qualityMod(m_quality);
+	return m_value * DBH::qualityMod( m_quality );
 }
 
 unsigned int Item::madeBy() const

--- a/src/game/item.h
+++ b/src/game/item.h
@@ -117,7 +117,7 @@ private:
 	unsigned short m_materialUID = 0;
 	unsigned short m_itemUID     = 0;
 
-	bool m_isPickedUp    = false;
+	bool m_isPickedUp              = false;
 	bool m_isConstructedOrEquipped = false; // double use of the flag, should be safe because no constructed item can be equipped and vice versa
 
 	unsigned int m_isInStockpile = 0;

--- a/src/game/jobmanager.cpp
+++ b/src/game/jobmanager.cpp
@@ -191,7 +191,7 @@ bool JobManager::requiredItemsAvail( unsigned int jobID )
 			rim.available = false;
 
 			//is item craftable?
-			if( Global::craftable.contains( rim.itemSID ) )
+			if ( Global::craftable.contains( rim.itemSID ) )
 			{
 				// create craft job
 				Global::wsm().autoGenCraftJob( rim.itemSID, rim.materialSID, rim.count );
@@ -220,7 +220,7 @@ bool JobManager::workPositionWalkable( unsigned int jobID )
 				job.addPossibleWorkPosition( testPos );
 			}
 		}
-		
+
 		return job.possibleWorkPositions().size() > 0;
 	}
 	return false;

--- a/src/game/pasture.cpp
+++ b/src/game/pasture.cpp
@@ -199,7 +199,7 @@ void Pasture::addTile( Position& pos )
 	grofi.pos = pos;
 	m_fields.insert( pos.toInt(), grofi );
 
-	if( m_properties.animalSize != 0 )
+	if ( m_properties.animalSize != 0 )
 	{
 		m_properties.max = m_fields.size() / m_properties.animalSize;
 	}
@@ -215,11 +215,11 @@ void Pasture::onTick( quint64 tick )
 	for ( auto field : m_fields )
 	{
 		Tile& tile = Global::w().getTile( field.pos );
-		if( GameState::season != 3 )
+		if ( GameState::season != 3 )
 		{
 			if ( tile.flags & TileFlag::TF_GRASS )
 			{
-				if( tick % 500 == 0 )
+				if ( tick % 500 == 0 )
 				{
 					tile.vegetationLevel = qMin( 100, tile.vegetationLevel + 1 );
 				}
@@ -653,7 +653,7 @@ bool Pasture::removeTile( Position& pos )
 		m_properties.firstPos = Position();
 	}
 
-	if( m_properties.animalSize != 0 )
+	if ( m_properties.animalSize != 0 )
 	{
 		m_properties.max = m_fields.size() / m_properties.animalSize;
 	}
@@ -687,7 +687,7 @@ void Pasture::getInfo( int& numPlots, int& numMale, int& numFemale )
 	for ( auto id : m_animals )
 	{
 		Animal* animal = Global::cm().animal( id );
-		if( animal )
+		if ( animal )
 		{
 			if ( animal->gender() == Gender::MALE )
 			{
@@ -878,7 +878,6 @@ int Pasture::maxFoodLevel()
 	return m_properties.maxTroughCapacity;
 }
 
-
 bool Pasture::eatFromTrough()
 {
 	if ( m_properties.troughContent > 0 )
@@ -912,7 +911,7 @@ void Pasture::setAnimalType( QString type )
 	{
 		int numPlots = m_fields.size();
 
-		if( m_properties.animalSize != 0 )
+		if ( m_properties.animalSize != 0 )
 		{
 			m_properties.max = m_fields.size() / m_properties.animalSize;
 		}
@@ -960,7 +959,7 @@ bool Pasture::tameWild()
 {
 	return m_properties.tameWild;
 }
-	
+
 void Pasture::setTameWild( bool value )
 {
 	m_properties.tameWild = value;

--- a/src/game/room.cpp
+++ b/src/game/room.cpp
@@ -213,7 +213,7 @@ bool Room::checkRoofed()
 	{
 		Position pos = tile->pos;
 		pos.z        = pos.z + 1;
-		Tile& _tile   = Global::w().getTile( pos );
+		Tile& _tile  = Global::w().getTile( pos );
 		if ( !( _tile.floorType & FloorType::FT_SOLIDFLOOR ) )
 		{
 			roofed = false;

--- a/src/game/roommanager.cpp
+++ b/src/game/roommanager.cpp
@@ -79,7 +79,7 @@ void RoomManager::addRoom( Position firstClick, QList<QPair<Position, bool>> fie
 		}
 		sp.setType( type );
 
-		switch( type )
+		switch ( type )
 		{
 			case RoomType::PersonalRoom:
 				sp.setName( "Personal Room" );

--- a/src/game/worldconstructions.cpp
+++ b/src/game/worldconstructions.cpp
@@ -65,8 +65,8 @@ bool World::construct( QString constructionSID, Position pos, int rotation, QLis
 	//qDebug() << "world::construct() " << constructionSID << pos.toString() << rotation;
 	QVariantMap con = DB::selectRow( "Constructions", constructionSID );
 	QString type    = con.value( "Type" ).toString();
-	
-	int typeNum     = m_constructionSID2ENUM.value( type );
+
+	int typeNum = m_constructionSID2ENUM.value( type );
 
 	QStringList materialSIDs;
 	QVariantList materialUIDs;
@@ -1019,7 +1019,7 @@ bool World::constructItem( QString itemSID, Position pos, int rotation, QList<un
 	}
 	//qDebug() << "##" << type << group << itemSID;
 	// TODO remove this workaround
-	if( itemSID == "AlarmBell" )
+	if ( itemSID == "AlarmBell" )
 	{
 		group = "AlarmBell";
 	}
@@ -1166,7 +1166,7 @@ bool World::deconstruct2( QVariantMap constr, Position decPos, bool isFloor, Pos
 		QString type  = constr.value( "Type" ).toString();
 		QString group = constr.value( "Group" ).toString();
 		// TODO remove this workaround
-		if( Global::inv().itemSID( itemID ) == "AlarmBell" )
+		if ( Global::inv().itemSID( itemID ) == "AlarmBell" )
 		{
 			group = "AlarmBell";
 		}

--- a/src/game/worldgenerator.cpp
+++ b/src/game/worldgenerator.cpp
@@ -1462,7 +1462,7 @@ void WorldGenerator::createRivers()
 	{
 		int prevZ = m_dimZ - 1;
 
-		for ( int i = 0; i < worm.size(); ++i )
+		for ( size_t i = 0; i < worm.size(); ++i )
 		{
 			auto pos = worm[i];
 			Global::w().getFloorLevelBelow( pos, false );
@@ -1478,7 +1478,7 @@ void WorldGenerator::createRivers()
 	}
 	for ( auto worm : worms2 )
 	{
-		for ( int i = 0; i < worm.size(); ++i )
+		for ( size_t i = 0; i < worm.size(); ++i )
 		{
 			auto pos = worm[i];
 			carveRiver( world, pos );

--- a/src/gui/aggregatoragri.cpp
+++ b/src/gui/aggregatoragri.cpp
@@ -273,32 +273,32 @@ void AggregatorAgri::onUpdatePasture( unsigned int id )
 
 				auto foods = DB::select( "Food", "Animals", past->animalType() ).toString();
 
-				for( auto food : foods.split( "|" ) )
+				for ( auto food : foods.split( "|" ) )
 				{
 					auto mats = Global::inv().materialsForItem( food, 0 );
 
-					for( auto mat : mats )
+					for ( auto mat : mats )
 					{
 						QString name = S::s( "$MaterialName_" + mat ) + " " + S::s( "$ItemName_" + food );
-						GuiPastureFoodItem pfi{ food, mat, name, foodSettings.contains( food + "_" + mat ) };
+						GuiPastureFoodItem pfi { food, mat, name, foodSettings.contains( food + "_" + mat ) };
 						m_pastureInfo.food.append( pfi );
 					}
 				}
 			}
 			else
 			{
-				m_pastureInfo.numPlots   = 0;
-				m_pastureInfo.numMale    = 0;
-				m_pastureInfo.numFemale  = 0;
-				m_pastureInfo.maxMale    = 0;
-				m_pastureInfo.maxFemale  = 0;
-				m_pastureInfo.total      = 0;
-				m_pastureInfo.maxNumber  = 0;
-				m_pastureInfo.animalSize = 0;
-				m_pastureInfo.hayMax     = 0;
-				m_pastureInfo.hayCurrent = 0;
-				m_pastureInfo.foodMax    = 0;
-				m_pastureInfo.foodCurrent= 0;
+				m_pastureInfo.numPlots    = 0;
+				m_pastureInfo.numMale     = 0;
+				m_pastureInfo.numFemale   = 0;
+				m_pastureInfo.maxMale     = 0;
+				m_pastureInfo.maxFemale   = 0;
+				m_pastureInfo.total       = 0;
+				m_pastureInfo.maxNumber   = 0;
+				m_pastureInfo.animalSize  = 0;
+				m_pastureInfo.hayMax      = 0;
+				m_pastureInfo.hayCurrent  = 0;
+				m_pastureInfo.foodMax     = 0;
+				m_pastureInfo.foodCurrent = 0;
 			}
 
 			onRequestProductInfo( AgriType::Pasture, m_pastureInfo.ID );
@@ -542,22 +542,21 @@ void AggregatorAgri::onRequestProductInfo( AgriType type, unsigned int designati
 						}
 
 						m_pastureInfo.animals.clear();
-						for( const auto& id : pasture->animals() )
+						for ( const auto& id : pasture->animals() )
 						{
 							auto animal = Global::cm().animal( id );
-							if( animal )
+							if ( animal )
 							{
 								GuiPastureAnimal pa;
-								pa.id = id;
-								pa.name = animal->name();
-								pa.isYoung = animal->isYoung();
-								pa.gender = animal->gender();
+								pa.id        = id;
+								pa.name      = animal->name();
+								pa.isYoung   = animal->isYoung();
+								pa.gender    = animal->gender();
 								pa.toButcher = animal->toButcher();
 
 								m_pastureInfo.animals.append( pa );
 							}
 						}
-
 					}
 					m_pastureInfo.product = ga;
 					emit signalUpdatePasture( m_pastureInfo );
@@ -604,7 +603,7 @@ void AggregatorAgri::onSetMaxMale( unsigned int pastureID, int max )
 		}
 	}
 }
-	
+
 void AggregatorAgri::onSetMaxFemale( unsigned int pastureID, int max )
 {
 	if ( m_pastureInfo.ID == pastureID )
@@ -621,7 +620,7 @@ void AggregatorAgri::onSetButchering( unsigned int animalID, bool value )
 {
 	//qDebug() << "AggregatorAgri::onSetButchering" << animalID << value;
 	auto animal = Global::cm().animal( animalID );
-	if( animal )
+	if ( animal )
 	{
 		animal->setToButcher( value );
 	}
@@ -644,7 +643,7 @@ void AggregatorAgri::onSetFoodItemChecked( unsigned int pastureID, QString itemS
 		auto pasture = Global::fm().getPasture( pastureID );
 		if ( pasture )
 		{
-			if( checked )
+			if ( checked )
 			{
 				pasture->addFoodSetting( itemSID, materialSID );
 			}

--- a/src/gui/aggregatorinventory.cpp
+++ b/src/gui/aggregatorinventory.cpp
@@ -18,11 +18,8 @@
 #include "aggregatorinventory.h"
 
 #include "../base/global.h"
-
 #include "../game/inventory.h"
-
 #include "../gui/strings.h"
-
 
 AggregatorInventory::AggregatorInventory( QObject* parent )
 {
@@ -34,78 +31,77 @@ AggregatorInventory::~AggregatorInventory()
 
 void AggregatorInventory::onRequestCategories()
 {
-    m_categories.clear();
-    for( const auto& cat : Global::inv().categories() )
+	m_categories.clear();
+	for ( const auto& cat : Global::inv().categories() )
 	{
-        int catTotal = 0;
-        for( const auto& group : Global::inv().groups( cat ) )
+		int catTotal = 0;
+		for ( const auto& group : Global::inv().groups( cat ) )
 		{
-            int groupTotal = 0;
-            for( const auto& item : Global::inv().items( cat, group ) )
+			int groupTotal = 0;
+			for ( const auto& item : Global::inv().items( cat, group ) )
 			{
-                for( const auto& mat : Global::inv().materials( cat, group, item ) )
+				for ( const auto& mat : Global::inv().materials( cat, group, item ) )
 				{
-                    QString iName = S::s( "$ItemName_" + item );
-                    QString mName = S::s( "$MaterialName_" + mat );
-                    int total = Global::inv().itemCount( item, mat );
-                    int inSP = Global::inv().itemCountInStockpile( item, mat );
-                    groupTotal += total;
+					QString iName = S::s( "$ItemName_" + item );
+					QString mName = S::s( "$MaterialName_" + mat );
+					int total     = Global::inv().itemCount( item, mat );
+					int inSP      = Global::inv().itemCountInStockpile( item, mat );
+					groupTotal += total;
 				}
 			}
-            catTotal += groupTotal;
+			catTotal += groupTotal;
 		}
-        //if( catTotal > 0 )
+		//if( catTotal > 0 )
 		{
-            m_categories.append( { cat, S::s( "$CategoryName_" + cat ) } );
-        }
+			m_categories.append( { cat, S::s( "$CategoryName_" + cat ) } );
+		}
 	}
 
-    emit signalInventoryCategories( m_categories );
+	emit signalInventoryCategories( m_categories );
 }
 
 void AggregatorInventory::onRequestGroups( QString category )
 {
-    m_groups.clear();
+	m_groups.clear();
 
-    for( const auto& group : Global::inv().groups( category ) )
+	for ( const auto& group : Global::inv().groups( category ) )
 	{
-        int total = 0;
-        for( const auto& item : Global::inv().items( category, group ) )
+		int total = 0;
+		for ( const auto& item : Global::inv().items( category, group ) )
 		{
-            for( const auto& mat : Global::inv().materials( category, group, item ) )
+			for ( const auto& mat : Global::inv().materials( category, group, item ) )
 			{
-                total += Global::inv().itemCount( item, mat );
+				total += Global::inv().itemCount( item, mat );
 			}
 		}
-        //if( total )
+		//if( total )
 		{
-            m_groups.append( { group, S::s( "$GroupName_" + group ) } );
+			m_groups.append( { group, S::s( "$GroupName_" + group ) } );
 		}
 	}
 
-    emit signalInventoryGroups( m_groups );
+	emit signalInventoryGroups( m_groups );
 }
-    
+
 void AggregatorInventory::onRequestItems( QString category, QString group )
 {
-    m_items.clear();
+	m_items.clear();
 
-    for( const auto& item : Global::inv().items( category, group ) )
+	for ( const auto& item : Global::inv().items( category, group ) )
 	{
-        for( const auto& mat : Global::inv().materials( category, group, item ) )
+		for ( const auto& mat : Global::inv().materials( category, group, item ) )
 		{
-            QString iName = S::s( "$ItemName_" + item );
-            QString mName = S::s( "$MaterialName_" + mat );
-            int total = Global::inv().itemCount( item, mat );
-            int inSP = Global::inv().itemCountInStockpile( item, mat );
+			QString iName = S::s( "$ItemName_" + item );
+			QString mName = S::s( "$MaterialName_" + mat );
+			int total     = Global::inv().itemCount( item, mat );
+			int inSP      = Global::inv().itemCountInStockpile( item, mat );
 
-            //if( total > 0 )
+			//if( total > 0 )
 			{
-			    m_items.append( { iName, mName, inSP, total } );
-            }
+				m_items.append( { iName, mName, inSP, total } );
+			}
 		}
 	}
 
-    emit signalInventoryItems( m_items );
+	emit signalInventoryItems( m_items );
 }
-

--- a/src/gui/aggregatorrenderer.cpp
+++ b/src/gui/aggregatorrenderer.cpp
@@ -238,7 +238,7 @@ void AggregatorRenderer::onAllTileInfo()
 
 		tileUpdates.updates.push_back( update );
 
-		if ( tileUpdates.updates.size() >= batchSize )
+		if ( tileUpdates.updates.size() >= size_t( batchSize ) )
 		{
 			{
 				emit signalTileUpdates( tileUpdates );
@@ -276,7 +276,7 @@ void AggregatorRenderer::onUpdateAnyTileInfo( const QSet<unsigned int>& changeSe
 
 		tileUpdates.updates.push_back( update );
 
-		if ( tileUpdates.updates.size() >= batchSize )
+		if ( tileUpdates.updates.size() >= size_t( batchSize ) )
 		{
 			{
 				emit signalTileUpdates( tileUpdates );

--- a/src/gui/aggregatorrenderer.cpp
+++ b/src/gui/aggregatorrenderer.cpp
@@ -159,13 +159,13 @@ QHash<unsigned int, unsigned int> AggregatorRenderer::collectCreatures()
 
 	auto& creatureList = Global::cm().creatures();
 
-	for( auto creature : creatureList )
+	for ( auto creature : creatureList )
 	{
-		switch( creature->type() )
+		switch ( creature->type() )
 		{
 			case CreatureType::ANIMAL:
 			{
-				auto a = dynamic_cast<Animal*>( creature );
+				auto a             = dynamic_cast<Animal*>( creature );
 				unsigned int posID = a->getPos().toInt();
 				if ( !creatures.contains( posID ) && !a->isDead() )
 				{
@@ -195,7 +195,7 @@ QHash<unsigned int, unsigned int> AggregatorRenderer::collectCreatures()
 			break;
 			case CreatureType::MONSTER:
 			{
-				auto m = dynamic_cast<Monster*>( creature );
+				auto m             = dynamic_cast<Monster*>( creature );
 				unsigned int posID = m->getPos().toInt();
 				if ( !creatures.contains( posID ) && !m->isDead() )
 				{
@@ -210,7 +210,7 @@ QHash<unsigned int, unsigned int> AggregatorRenderer::collectCreatures()
 			}
 		}
 	}
-	
+
 	return creatures;
 }
 

--- a/src/gui/aggregatorrenderer.cpp
+++ b/src/gui/aggregatorrenderer.cpp
@@ -238,7 +238,7 @@ void AggregatorRenderer::onAllTileInfo()
 
 		tileUpdates.updates.push_back( update );
 
-		if ( tileUpdates.updates.size() >= size_t( batchSize ) )
+		if ( tileUpdates.updates.size() >= static_cast<size_t>( batchSize ) )
 		{
 			{
 				emit signalTileUpdates( tileUpdates );
@@ -276,7 +276,7 @@ void AggregatorRenderer::onUpdateAnyTileInfo( const QSet<unsigned int>& changeSe
 
 		tileUpdates.updates.push_back( update );
 
-		if ( tileUpdates.updates.size() >= size_t( batchSize ) )
+		if ( static_cast<size_t>( tileUpdates.updates.size() ) >= batchSize )
 		{
 			{
 				emit signalTileUpdates( tileUpdates );

--- a/src/gui/aggregatorworkshop.cpp
+++ b/src/gui/aggregatorworkshop.cpp
@@ -268,7 +268,7 @@ void AggregatorWorkshop::onCraftJobParams( unsigned int workshopID, unsigned int
 void AggregatorWorkshop::onRequestAllTradeItems( unsigned int workshopID )
 {
 	updateTraderStock( workshopID );
-	
+
 	updatePlayerStock( workshopID );
 }
 
@@ -276,7 +276,7 @@ void AggregatorWorkshop::updateTraderStock( unsigned int workshopID )
 {
 	auto workshop = Global::wsm().workshop( workshopID );
 
-	if( workshop )
+	if ( workshop )
 	{
 		unsigned int traderID = workshop->assignedGnome();
 
@@ -284,13 +284,13 @@ void AggregatorWorkshop::updateTraderStock( unsigned int workshopID )
 
 		m_traderStock.clear();
 
-		if( traderID )
+		if ( traderID )
 		{
 			GnomeTrader* gt = Global::gm().trader( traderID );
-			if( gt )
+			if ( gt )
 			{
 				auto& items = gt->inventory();
-					
+
 				updateTraderStock( items );
 
 				emit signalTraderStock( m_traderStock );
@@ -305,30 +305,30 @@ void AggregatorWorkshop::updateTraderStock( const QList<TraderItem>& source )
 {
 	m_traderStock.clear();
 
-	for( auto item : source )
+	for ( auto item : source )
 	{
 		GuiTradeItem gti;
-		gti.itemSID = item.itemSID;
-		gti.value = item.value;
-		gti.count = item.amount;
+		gti.itemSID  = item.itemSID;
+		gti.value    = item.value;
+		gti.count    = item.amount;
 		gti.reserved = item.reserved;
-		gti.quality = item.quality;
+		gti.quality  = item.quality;
 
-		if( item.type == "Animal" )
+		if ( item.type == "Animal" )
 		{
 			gti.materialSIDorGender = item.gender;
-			gti.name = 	gti.materialSIDorGender + " " + S::s( "$CreatureName_" + gti.itemSID ) + " (" + QString::number( gti.value ) + ")";
+			gti.name                = gti.materialSIDorGender + " " + S::s( "$CreatureName_" + gti.itemSID ) + " (" + QString::number( gti.value ) + ")";
 		}
 		else
 		{
 			gti.materialSIDorGender = item.materialSID;
-			
+
 			QString qName;
 			QString qID;
-			if( DB::select( "HasQuality", "Items", gti.itemSID ).toBool() )
+			if ( DB::select( "HasQuality", "Items", gti.itemSID ).toBool() )
 			{
-				qID = DBH::qualitySID( 3 );
-				qName= S::s( "$QualityName_" + qID ) + " ";
+				qID   = DBH::qualitySID( 3 );
+				qName = S::s( "$QualityName_" + qID ) + " ";
 			}
 
 			gti.name = qName + S::s( "$MaterialName_" + gti.materialSIDorGender ) + " " + S::s( "$ItemName_" + gti.itemSID ) + " (" + QString::number( gti.value ) + ")";
@@ -336,56 +336,56 @@ void AggregatorWorkshop::updateTraderStock( const QList<TraderItem>& source )
 		m_traderStock.append( gti );
 	}
 }
-	
+
 void AggregatorWorkshop::updatePlayerStock( unsigned int workshopID )
 {
 	m_playerStock.clear();
 
 	Inventory& inv = Global::inv();
 
-	for( auto category : inv.categories() )
+	for ( auto category : inv.categories() )
 	{
-		for( auto group : inv.groups( category ) )
+		for ( auto group : inv.groups( category ) )
 		{
-			for( auto item : inv.items( category, group ) )
+			for ( auto item : inv.items( category, group ) )
 			{
 				QList<QString> mats = inv.materials( category, group, item );
-				for( auto mat : mats )
+				for ( auto mat : mats )
 				{
 					int count = inv.itemCountInStockpile( item, mat );
-					if( count > 0 )
+					if ( count > 0 )
 					{
 						QList<unsigned int> itemList = inv.tradeInventory( item, mat );
 
 						Counter<unsigned int> counter;
-						QMap<unsigned int, unsigned int>values;
+						QMap<unsigned int, unsigned int> values;
 						QMap<int, QList<unsigned int>> vlItems;
-						for( auto itemUID : itemList )
+						for ( auto itemUID : itemList )
 						{
 							int qual = inv.quality( itemUID );
 							counter.add( qual );
 							vlItems[qual].append( itemUID );
 						}
-						for( auto key : counter.keys() )
+						for ( auto key : counter.keys() )
 						{
 							GuiTradeItem gti;
 
 							QString qName;
 							QString qID;
-							if( DB::select( "HasQuality", "Items", item ).toBool() )
+							if ( DB::select( "HasQuality", "Items", item ).toBool() )
 							{
-								qID = DBH::qualitySID( (int)key );
-								qName= S::s( "$QualityName_" + qID ) + " ";
+								qID   = DBH::qualitySID( (int)key );
+								qName = S::s( "$QualityName_" + qID ) + " ";
 							}
 
-							gti.itemSID = item;
+							gti.itemSID             = item;
 							gti.materialSIDorGender = mat;
-							gti.value = inv.getTradeValue( item, mat, key );
-							gti.quality = key; 
-							gti.count = count;
+							gti.value               = inv.getTradeValue( item, mat, key );
+							gti.quality             = key;
+							gti.count               = count;
 
 							gti.name = qName + S::s( "$MaterialName_" + mat ) + " " + S::s( "$ItemName_" + item ) + " (" + QString::number( gti.value ) + ")";
-							
+
 							m_playerStock.append( gti );
 						}
 					}
@@ -394,35 +394,34 @@ void AggregatorWorkshop::updatePlayerStock( unsigned int workshopID )
 		}
 	}
 	emit signalPlayerStock( m_playerStock );
-
 }
 
 void AggregatorWorkshop::onTraderStocktoOffer( unsigned int workshopID, QString itemSID, QString materialSID, unsigned char quality, int count )
 {
 	auto workshop = Global::wsm().workshop( workshopID );
 
-	if( workshop )
+	if ( workshop )
 	{
 		unsigned int traderID = workshop->assignedGnome();
-		
+
 		m_traderID = traderID;
 
-		if( traderID )
+		if ( traderID )
 		{
 			GnomeTrader* gt = Global::gm().trader( traderID );
-			if( gt )
+			if ( gt )
 			{
 				auto& items = gt->inventory();
-					
-				for( auto& item : items )
+
+				for ( auto& item : items )
 				{
-					if( item.itemSID == itemSID && ( item.materialSID == materialSID || item.gender == materialSID ) && item.quality == quality )
+					if ( item.itemSID == itemSID && ( item.materialSID == materialSID || item.gender == materialSID ) && item.quality == quality )
 					{
 						item.reserved = qMin( item.amount, item.reserved + count );
 
-						for( auto& gti : m_traderStock )
+						for ( auto& gti : m_traderStock )
 						{
-							if( gti.itemSID == itemSID && gti.materialSIDorGender == materialSID && gti.quality == quality )
+							if ( gti.itemSID == itemSID && gti.materialSIDorGender == materialSID && gti.quality == quality )
 							{
 								gti.reserved = item.reserved;
 								emit signalUpdateTraderStockItem( gti );
@@ -437,33 +436,33 @@ void AggregatorWorkshop::onTraderStocktoOffer( unsigned int workshopID, QString 
 		}
 	}
 }
-	
+
 void AggregatorWorkshop::onTraderOffertoStock( unsigned int workshopID, QString itemSID, QString materialSID, unsigned char quality, int count )
 {
 	auto workshop = Global::wsm().workshop( workshopID );
 
-	if( workshop )
+	if ( workshop )
 	{
 		unsigned int traderID = workshop->assignedGnome();
-		
+
 		m_traderID = traderID;
 
-		if( traderID )
+		if ( traderID )
 		{
 			GnomeTrader* gt = Global::gm().trader( traderID );
-			if( gt )
+			if ( gt )
 			{
 				auto& items = gt->inventory();
-					
-				for( auto& item : items )
+
+				for ( auto& item : items )
 				{
-					if( item.itemSID == itemSID && item.materialSID == materialSID && item.quality == quality )
+					if ( item.itemSID == itemSID && item.materialSID == materialSID && item.quality == quality )
 					{
 						item.reserved = qMax( 0, item.reserved - count );
 
-						for( auto& gti : m_traderStock )
+						for ( auto& gti : m_traderStock )
 						{
-							if( gti.itemSID == itemSID && gti.materialSIDorGender == materialSID && gti.quality == quality )
+							if ( gti.itemSID == itemSID && gti.materialSIDorGender == materialSID && gti.quality == quality )
 							{
 								gti.reserved = item.reserved;
 								emit signalUpdateTraderStockItem( gti );
@@ -481,12 +480,12 @@ void AggregatorWorkshop::onTraderOffertoStock( unsigned int workshopID, QString 
 
 void AggregatorWorkshop::onPlayerStocktoOffer( unsigned int workshopID, QString itemSID, QString materialSID, unsigned char quality, int count )
 {
-	for( auto& item : m_playerStock )
+	for ( auto& item : m_playerStock )
 	{
-		if( item.itemSID == itemSID && item.materialSIDorGender == materialSID && item.quality == quality )
+		if ( item.itemSID == itemSID && item.materialSIDorGender == materialSID && item.quality == quality )
 		{
 			item.reserved = qMin( item.count, item.reserved + count );
-		
+
 			emit signalUpdatePlayerStockItem( item );
 			updatePlayerValue();
 			break;
@@ -496,12 +495,12 @@ void AggregatorWorkshop::onPlayerStocktoOffer( unsigned int workshopID, QString 
 
 void AggregatorWorkshop::onPlayerOffertoStock( unsigned int workshopID, QString itemSID, QString materialSID, unsigned char quality, int count )
 {
-	for( auto& item : m_playerStock )
+	for ( auto& item : m_playerStock )
 	{
-		if( item.itemSID == itemSID && item.materialSIDorGender == materialSID && item.quality == quality )
+		if ( item.itemSID == itemSID && item.materialSIDorGender == materialSID && item.quality == quality )
 		{
 			item.reserved = qMax( 0, item.reserved - count );
-		
+
 			emit signalUpdatePlayerStockItem( item );
 			updatePlayerValue();
 			break;
@@ -512,17 +511,17 @@ void AggregatorWorkshop::onPlayerOffertoStock( unsigned int workshopID, QString 
 void AggregatorWorkshop::updateTraderValue()
 {
 	m_traderOfferValue = 0;
-	for( const auto& item : m_traderStock )
+	for ( const auto& item : m_traderStock )
 	{
 		m_traderOfferValue += item.reserved * item.value;
 	}
 	emit signalUpdateTraderValue( m_traderOfferValue );
 }
-	
+
 void AggregatorWorkshop::updatePlayerValue()
 {
 	m_playerOfferValue = 0;
-	for( const auto& item : m_playerStock )
+	for ( const auto& item : m_playerStock )
 	{
 		m_playerOfferValue += item.reserved * item.value;
 	}
@@ -533,31 +532,30 @@ void AggregatorWorkshop::onTrade( unsigned int workshopID )
 {
 	auto workshop = Global::wsm().workshop( workshopID );
 
-	if( workshop )
+	if ( workshop )
 	{
 		unsigned int traderID = workshop->assignedGnome();
 
 		m_traderID = traderID;
 
-		if( traderID )
+		if ( traderID )
 		{
 			GnomeTrader* gt = Global::gm().trader( traderID );
-			if( gt )
+			if ( gt )
 			{
-				if( m_playerOfferValue >= m_traderOfferValue )
+				if ( m_playerOfferValue >= m_traderOfferValue )
 				{
 					QList<unsigned int> allItemsToSell;
-					for( auto& item : m_playerStock )
+					for ( auto& item : m_playerStock )
 					{
 						auto sellItems = Global::inv().tradeInventory( item.itemSID, item.materialSIDorGender, item.quality );
 
-						if( sellItems.size() >= item.reserved )
+						if ( sellItems.size() >= item.reserved )
 						{
-							for( int i = 0; i < item.reserved; ++i )
+							for ( int i = 0; i < item.reserved; ++i )
 							{
 								allItemsToSell.append( sellItems[i] );
 							}
-				
 						}
 						else
 						{
@@ -566,13 +564,13 @@ void AggregatorWorkshop::onTrade( unsigned int workshopID )
 						}
 					}
 					int currentValue = 0;
-					for( auto itemID : allItemsToSell )
+					for ( auto itemID : allItemsToSell )
 					{
 						currentValue += Global::inv().value( itemID );
 					}
-					if( currentValue >= m_traderOfferValue )
+					if ( currentValue >= m_traderOfferValue )
 					{
-						for( auto itemID : allItemsToSell )
+						for ( auto itemID : allItemsToSell )
 						{
 							Global::inv().pickUpItem( itemID );
 							Global::inv().destroyObject( itemID );
@@ -580,11 +578,11 @@ void AggregatorWorkshop::onTrade( unsigned int workshopID )
 						updatePlayerStock( workshopID );
 
 						auto& traderItems = gt->inventory();
-						for( auto& item : traderItems )
+						for ( auto& item : traderItems )
 						{
-							if( item.type == "Animal" )
+							if ( item.type == "Animal" )
 							{
-								for( int i = 0; i < item.reserved; ++i )
+								for ( int i = 0; i < item.reserved; ++i )
 								{
 									Gender gender = item.gender == "Male" ? Gender::MALE : Gender::FEMALE;
 
@@ -593,12 +591,12 @@ void AggregatorWorkshop::onTrade( unsigned int workshopID )
 							}
 							else
 							{
-								for( int i = 0; i < item.reserved; ++i )
+								for ( int i = 0; i < item.reserved; ++i )
 								{
 									Global::inv().createItem( workshop->outputPos(), item.itemSID, item.materialSID );
 								}
 							}
-							item.amount = qMax( 0, item.amount - item.reserved );
+							item.amount   = qMax( 0, item.amount - item.reserved );
 							item.reserved = 0;
 						}
 

--- a/src/gui/eventconnector.cpp
+++ b/src/gui/eventconnector.cpp
@@ -38,7 +38,7 @@ EventConnector::EventConnector( QObject* parent ) :
 	m_debugAggregator        = new AggregatorDebug( this );
 	m_neighborsAggregator    = new AggregatorNeighbors( this );
 	m_militaryAggregator     = new AggregatorMilitary( this );
-	m_settingsAggregator	 = new AggregatorSettings( this );
+	m_settingsAggregator     = new AggregatorSettings( this );
 	m_inventoryAggregator    = new AggregatorInventory( this );
 }
 
@@ -65,7 +65,6 @@ void EventConnector::onKingdomInfo( QString name, QString info1, QString info2, 
 {
 	emit signalKingdomInfo( name, info1, info2, info3 );
 }
-
 
 void EventConnector::onViewLevel( int level )
 {

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -25,9 +25,9 @@
 #include "../base/tile.h"
 #include "../game/gamemanager.h"
 #include "../game/world.h"
-#include "../gui/eventconnector.h"
 #include "../gui/aggregatordebug.h"
 #include "../gui/aggregatorsettings.h"
+#include "../gui/eventconnector.h"
 #include "license.h"
 #include "mainwindowrenderer.h"
 #include "xaml/GameGui.xaml.h"
@@ -51,13 +51,13 @@
 #include "xaml/WaitPage.xaml.h"
 #include "xaml/agriculture.xaml.h"
 #include "xaml/agriculturemodel.h"
+#include "xaml/converters.h"
 #include "xaml/creatureinfo.xaml.h"
 #include "xaml/creatureinfomodel.h"
 #include "xaml/debug.xaml.h"
 #include "xaml/debugmodel.h"
 #include "xaml/inventory.xaml.h"
 #include "xaml/inventorymodel.h"
-
 #include "xaml/military.xaml.h"
 #include "xaml/militarymodel.h"
 #include "xaml/neighbors.xaml.h"
@@ -65,8 +65,6 @@
 #include "xaml/stockpilegui.xaml.h"
 #include "xaml/workshopgui.xaml.h"
 #include "xaml/workshopmodel.h"
-
-#include "xaml/converters.h"
 
 #include <NsApp/Launcher.h>
 #include <NsApp/LocalFontProvider.h>
@@ -123,14 +121,14 @@ MainWindow::~MainWindow()
 {
 	qDebug() << "MainWindow destructor";
 
-	if( !m_isFullScreen )
+	if ( !m_isFullScreen )
 	{
 		Config::getInstance().set( "WindowWidth", this->width() );
 		Config::getInstance().set( "WindowHeight", this->height() );
 		Config::getInstance().set( "WindowPosX", this->position().x() );
 		Config::getInstance().set( "WindowPosY", this->position().y() );
 	}
-	
+
 	IO::saveConfig();
 	instance = nullptr;
 }
@@ -148,7 +146,7 @@ void MainWindow::onExit()
 void MainWindow::toggleFullScreen()
 {
 	QOpenGLWindow* w = this;
-	m_isFullScreen = !m_isFullScreen;
+	m_isFullScreen   = !m_isFullScreen;
 	if ( m_isFullScreen )
 	{
 		w->showFullScreen();
@@ -166,7 +164,7 @@ void MainWindow::toggleFullScreen()
 void MainWindow::onFullScreen( bool value )
 {
 	QOpenGLWindow* w = this;
-	m_isFullScreen = value;
+	m_isFullScreen   = value;
 	Config::getInstance().set( "fullscreen", value );
 	if ( value )
 	{
@@ -182,13 +180,13 @@ void MainWindow::onFullScreen( bool value )
 
 void MainWindow::keyPressEvent( QKeyEvent* event )
 {
-	int qtKey = event->key();
+	int qtKey      = event->key();
 	auto noesisKey = Global::keyConvert( (Qt::Key)qtKey );
 	//qDebug() << "keyPressEvent" << event->key() << " " << event->text() << noesisKey;
 
 	bool ret = false;
-	
-	if( qtKey != 32 )
+
+	if ( qtKey != 32 )
 	{
 		ret = m_view->KeyDown( noesisKey );
 	}
@@ -201,7 +199,7 @@ void MainWindow::keyPressEvent( QKeyEvent* event )
 			ret |= m_view->Char( c.unicode() );
 		}
 	}
-	
+
 	if ( ret )
 	{
 		noesisTick();
@@ -302,14 +300,19 @@ bool MainWindow::isOverGui( int x, int y )
 
 void MainWindow::keyboardMove()
 {
-	if( m_keyboardMove == KeyboardMove::None ) return;
+	if ( m_keyboardMove == KeyboardMove::None )
+		return;
 
 	int x = 0;
 	int y = 0;
-	if( (bool)( m_keyboardMove & KeyboardMove::Up ) ) y -= 1;
-	if( (bool)( m_keyboardMove & KeyboardMove::Down ) ) y += 1;
-	if( (bool)( m_keyboardMove & KeyboardMove::Left ) ) x -= 1;
-	if( (bool)( m_keyboardMove & KeyboardMove::Right ) ) x += 1;
+	if ( (bool)( m_keyboardMove & KeyboardMove::Up ) )
+		y -= 1;
+	if ( (bool)( m_keyboardMove & KeyboardMove::Down ) )
+		y += 1;
+	if ( (bool)( m_keyboardMove & KeyboardMove::Left ) )
+		x -= 1;
+	if ( (bool)( m_keyboardMove & KeyboardMove::Right ) )
+		x += 1;
 
 	float keyboardMoveSpeed = Config::getInstance().get( "keyboardMoveSpeed" ).toFloat();
 
@@ -318,7 +321,7 @@ void MainWindow::keyboardMove()
 	int moveX = -( x * keyboardMoveSpeed ) / scale;
 	int moveY = -( y * keyboardMoveSpeed ) / scale;
 
-	if( m_renderer )
+	if ( m_renderer )
 	{
 		m_renderer->move( moveX, moveY );
 	}
@@ -358,8 +361,8 @@ void MainWindow::mouseMoveEvent( QMouseEvent* event )
 		}
 	}
 
-	m_mouseX  = gp.x();
-	m_mouseY  = gp.y();
+	m_mouseX = gp.x();
+	m_mouseY = gp.y();
 
 	if ( Selection::getInstance().hasAction() )
 	{
@@ -378,7 +381,7 @@ void MainWindow::onInitViewAfterLoad()
 	m_moveX = config.get( "moveX" ).toInt();
 	m_moveY = config.get( "moveY" ).toInt();
 	m_renderer->move( m_moveX, m_moveY );
-	
+
 	float scale = config.get( "scale" ).toFloat();
 	m_renderer->setScale( scale );
 }
@@ -704,7 +707,7 @@ void MainWindow::resizeGL( int w, int h )
 {
 	QOpenGLWindow::resizeGL( w, h );
 
-	if( !m_isFullScreen )
+	if ( !m_isFullScreen )
 	{
 		Config::getInstance().set( "WindowWidth", w );
 		Config::getInstance().set( "WindowHeight", h );

--- a/src/gui/mainwindowrenderer.cpp
+++ b/src/gui/mainwindowrenderer.cpp
@@ -97,28 +97,27 @@ MainWindowRenderer::MainWindowRenderer( MainWindow* parent ) :
 	qDebug() << m_parent->context()->format();
 
 	QOpenGLExtraFunctions* f = QOpenGLContext::currentContext()->extraFunctions();
-	GLDEBUGPROC logHandler   = []( GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam ) -> void
-	{
-		static const std::unordered_map<GLenum, const char*> debugTypes = {
-			{ GL_DEBUG_TYPE_ERROR, "Error" },
-			{ GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR, "DeprecatedBehavior" },
-			{ GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR, "UndefinedBehavior" },
-			{ GL_DEBUG_TYPE_PORTABILITY, "Portability" },
-			{ GL_DEBUG_TYPE_PERFORMANCE, "Performance" },
-			{ GL_DEBUG_TYPE_MARKER, "Marker" },
-			{ GL_DEBUG_TYPE_OTHER, "Other" },
-			{ GL_DEBUG_TYPE_PUSH_GROUP, "Push" },
-			{ GL_DEBUG_TYPE_POP_GROUP, "Pop" }
-		};
-		static const std::unordered_map<GLenum, const char*> severities = {
-			{ GL_DEBUG_SEVERITY_LOW, "low" },
-			{ GL_DEBUG_SEVERITY_MEDIUM, "medium" },
-			{ GL_DEBUG_SEVERITY_HIGH, "high" },
-			{ GL_DEBUG_SEVERITY_NOTIFICATION, "notify" },
-		};
-		if ( severity == GL_DEBUG_SEVERITY_NOTIFICATION && !Global::debugMode )
-			return;
-		qDebug() << "[OpenGL]" << debugTypes.at( type ) << " " << severities.at(severity) << ":" << message;
+	GLDEBUGPROC logHandler   = []( GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam ) -> void {
+        static const std::unordered_map<GLenum, const char*> debugTypes = {
+            { GL_DEBUG_TYPE_ERROR, "Error" },
+            { GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR, "DeprecatedBehavior" },
+            { GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR, "UndefinedBehavior" },
+            { GL_DEBUG_TYPE_PORTABILITY, "Portability" },
+            { GL_DEBUG_TYPE_PERFORMANCE, "Performance" },
+            { GL_DEBUG_TYPE_MARKER, "Marker" },
+            { GL_DEBUG_TYPE_OTHER, "Other" },
+            { GL_DEBUG_TYPE_PUSH_GROUP, "Push" },
+            { GL_DEBUG_TYPE_POP_GROUP, "Pop" }
+        };
+        static const std::unordered_map<GLenum, const char*> severities = {
+            { GL_DEBUG_SEVERITY_LOW, "low" },
+            { GL_DEBUG_SEVERITY_MEDIUM, "medium" },
+            { GL_DEBUG_SEVERITY_HIGH, "high" },
+            { GL_DEBUG_SEVERITY_NOTIFICATION, "notify" },
+        };
+        if ( severity == GL_DEBUG_SEVERITY_NOTIFICATION && !Global::debugMode )
+            return;
+        qDebug() << "[OpenGL]" << debugTypes.at( type ) << " " << severities.at( severity ) << ":" << message;
 	};
 	glEnable( GL_DEBUG_OUTPUT );
 	f->glDebugMessageCallback( logHandler, nullptr );
@@ -373,10 +372,10 @@ void MainWindowRenderer::createArrayTexture( int unit, int depth )
 	glBindTexture( GL_TEXTURE_2D_ARRAY, m_textures[unit] );
 	glTexStorage3D(
 		GL_TEXTURE_2D_ARRAY,
-		1,             // No mipmaps
-		GL_RGBA8,      // Internal format
-		32, 64,        // width,height
-		depth          // Number of layers
+		1,        // No mipmaps
+		GL_RGBA8, // Internal format
+		32, 64,   // width,height
+		depth     // Number of layers
 	);
 	glTexParameteri( GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_NEAREST );
 	glTexParameteri( GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_NEAREST );
@@ -395,8 +394,7 @@ void MainWindowRenderer::uploadArrayTexture( int unit, int depth, const uint8_t*
 		32, 64, depth,    // width, height, depth
 		GL_RGBA,          // format
 		GL_UNSIGNED_BYTE, // type
-		data
-	);
+		data );
 }
 
 void MainWindowRenderer::initTextures()
@@ -422,7 +420,6 @@ void MainWindowRenderer::initTextures()
 	{
 		uploadArrayTexture( i, maxArrayTextures, sf.pixelData( i ).cbegin() );
 	}
-
 
 	//qDebug() << "stored " << maxArrayTextures << " pixmaps in array texture";
 
@@ -673,7 +670,7 @@ void MainWindowRenderer::paintSelection()
 {
 	// TODO this is a workaround until some transparency solution is implemented
 	auto action = Selection::getInstance().action();
-	if( action == "DigStairsDown" || action == "DigRampDown" )
+	if ( action == "DigStairsDown" || action == "DigRampDown" )
 	{
 		glDisable( GL_DEPTH_TEST );
 	}
@@ -699,7 +696,7 @@ void MainWindowRenderer::paintSelection()
 	}
 
 	m_selectionShader->release();
-	if( action == "DigStairsDown" || action == "DigRampDown" )
+	if ( action == "DigStairsDown" || action == "DigRampDown" )
 	{
 		glEnable( GL_DEPTH_TEST );
 	}
@@ -772,7 +769,7 @@ void MainWindowRenderer::rotate( int direction )
 	m_rotation = ( 4 + m_rotation + direction ) % 4;
 	Config::getInstance().set( "rotation", m_rotation );
 
-	if( direction == 1 )
+	if ( direction == 1 )
 	{
 		updatePositionAfterCWRotation( m_moveX, m_moveY );
 	}
@@ -1206,7 +1203,7 @@ Position MainWindowRenderer::calcCursor( int mouseX, int mouseY, bool isFloor, b
 		if ( cursorPos.z > 0 )
 		{
 			Tile& tileBelow = world.getTile( cursorPos.x, cursorPos.y, cursorPos.z - 1 );
-			if( isFloor && tile.floorType == FloorType::FT_NOFLOOR && tileBelow.wallType != WallType::WT_NOWALL )
+			if ( isFloor && tile.floorType == FloorType::FT_NOFLOOR && tileBelow.wallType != WallType::WT_NOWALL )
 			{
 				zFloorFound = true;
 			}
@@ -1253,8 +1250,8 @@ Position MainWindowRenderer::calcCursor( int mouseX, int mouseY, bool isFloor, b
 void MainWindowRenderer::updatePositionAfterCWRotation( float& x, float& y )
 {
 	constexpr int tileHeight = 8; //tiles are assumed to be 8 pixels high (and twice as wide)
-	int tmp = x;
-	x = -2 * ( Global::dimX * tileHeight + y );
+	int tmp                  = x;
+	x                        = -2 * ( Global::dimX * tileHeight + y );
 	//y = -Global::dimY * tileHeight + tmp/2;
-	y = -( Global::dimY - 2 ) * tileHeight + tmp/2;
+	y = -( Global::dimY - 2 ) * tileHeight + tmp / 2;
 }

--- a/src/gui/xaml/GameModel.cpp
+++ b/src/gui/xaml/GameModel.cpp
@@ -148,7 +148,7 @@ BuildItem::BuildItem( QString name, QString sid, BuildItemType type )
 		{
 			auto rows = DB::selectRows( "Constructions_Components", sid );
 
-			if( rows.size() )
+			if ( rows.size() )
 			{
 				for ( auto row : rows )
 				{
@@ -159,7 +159,6 @@ BuildItem::BuildItem( QString name, QString sid, BuildItemType type )
 			{
 				m_requiredItems->Add( MakePtr<NRequiredItem>( sid, 1 ) );
 			}
-
 
 			QStringList mats;
 			for ( int i = 0; i < 25; ++i )
@@ -199,9 +198,9 @@ const NoesisApp::DelegateCommand* BuildItem::GetCmdBuild() const
 
 const char* BuildItem::GetShowReplaceButton() const
 {
-	if( m_type == BuildItemType::Terrain )
+	if ( m_type == BuildItemType::Terrain )
 	{
-		if( m_sid.endsWith( "Wall" ) || m_sid.endsWith( "Floor" ) || m_sid.startsWith( "FancyFloor" ) ||  m_sid.startsWith( "FancyWall" ) )
+		if ( m_sid.endsWith( "Wall" ) || m_sid.endsWith( "Floor" ) || m_sid.startsWith( "FancyFloor" ) || m_sid.startsWith( "FancyWall" ) )
 		{
 			return "Visible";
 		}
@@ -211,9 +210,9 @@ const char* BuildItem::GetShowReplaceButton() const
 
 const char* BuildItem::GetShowFillHoleButton() const
 {
-	if( m_type == BuildItemType::Terrain )
+	if ( m_type == BuildItemType::Terrain )
 	{
-		if( m_sid.endsWith( "Wall" ) || m_sid.startsWith( "FancyWall" ) )
+		if ( m_sid.endsWith( "Wall" ) || m_sid.startsWith( "FancyWall" ) )
 		{
 			return "Visible";
 		}
@@ -246,11 +245,11 @@ void BuildItem::onCmdBuild( BaseComponent* param )
 		case BuildItemType::Terrain:
 		{
 			QString type = DB::select( "Type", "Constructions", m_sid ).toString();
-			
-			if( param )
+
+			if ( param )
 			{
 				QString qParam = param->ToString().Str();
-				if( qParam == "FillHole" )
+				if ( qParam == "FillHole" )
 				{
 					Selection::getInstance().setAction( qParam );
 				}
@@ -277,7 +276,6 @@ void BuildItem::onCmdBuild( BaseComponent* param )
 
 	EventConnector::getInstance().onBuild();
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 NRequiredItem::NRequiredItem( QString sid, int amount )
@@ -376,7 +374,7 @@ GameModel::GameModel()
 	m_messageButtonCmd.SetExecuteFunc( MakeDelegate( this, &GameModel::onMessageButtonCmd ) );
 
 	m_messageHeader = "Message header";
-	m_messageText = "Message text Message text Message text Message text Message text Message text Message text Message text Message text Message text Message text Message text Message text";
+	m_messageText   = "Message text Message text Message text Message text Message text Message text Message text Message text Message text Message text Message text Message text Message text";
 
 	m_proxy = new ProxyGameView;
 	m_proxy->setParent( this );
@@ -474,7 +472,6 @@ void GameModel::setTimeAndDate( int minute, int hour, int day, QString season, i
 			OnPropertyChanged( "TimeImagePath" );
 		}
 	}
-
 }
 
 void GameModel::setViewLevel( int level )
@@ -548,7 +545,7 @@ const char* GameModel::getSun() const
 {
 	return m_sun.Str();
 }
-	
+
 const char* GameModel::getKingdomName() const
 {
 	return m_kingdomName.Str();
@@ -711,12 +708,12 @@ const char* GameModel::getShowPopulation() const
 	}
 	return "Hidden";
 }
-	
+
 void GameModel::setShowPopulation( bool value )
 {
-	if( value )
+	if ( value )
 	{
-		if( m_shownInfo != ShownInfo::Population )
+		if ( m_shownInfo != ShownInfo::Population )
 		{
 			setShownInfo( ShownInfo::Population );
 		}
@@ -727,7 +724,6 @@ void GameModel::setShowPopulation( bool value )
 	}
 }
 
-	
 const char* GameModel::getShowDebug() const
 {
 	if ( m_shownInfo == ShownInfo::Debug )
@@ -739,9 +735,9 @@ const char* GameModel::getShowDebug() const
 
 void GameModel::setShowDebug( bool value )
 {
-	if( value )
+	if ( value )
 	{
-		if( m_shownInfo != ShownInfo::Debug )
+		if ( m_shownInfo != ShownInfo::Debug )
 		{
 			setShownInfo( ShownInfo::Debug );
 		}
@@ -763,9 +759,9 @@ const char* GameModel::getShowNeighbors() const
 
 void GameModel::setShowNeighbors( bool value )
 {
-	if( value )
+	if ( value )
 	{
-		if( m_shownInfo != ShownInfo::Neighbors )
+		if ( m_shownInfo != ShownInfo::Neighbors )
 		{
 			setShownInfo( ShownInfo::Neighbors );
 		}
@@ -787,9 +783,9 @@ const char* GameModel::getShowMilitary() const
 
 void GameModel::setShowMilitary( bool value )
 {
-	if( value )
+	if ( value )
 	{
-		if( m_shownInfo != ShownInfo::Military )
+		if ( m_shownInfo != ShownInfo::Military )
 		{
 			setShownInfo( ShownInfo::Military );
 		}
@@ -811,9 +807,9 @@ const char* GameModel::getShowInventory() const
 
 void GameModel::setShowInventory( bool value )
 {
-	if( value )
+	if ( value )
 	{
-		if( m_shownInfo != ShownInfo::Inventory )
+		if ( m_shownInfo != ShownInfo::Inventory )
 		{
 			setShownInfo( ShownInfo::Inventory );
 		}
@@ -824,11 +820,9 @@ void GameModel::setShowInventory( bool value )
 	}
 }
 
-
-
 void GameModel::setGameSpeed( GameSpeed value )
 {
-	if( m_showMessageWindow )
+	if ( m_showMessageWindow )
 	{
 		m_proxy->setPaused( true );
 	}
@@ -852,7 +846,7 @@ bool GameModel::getPaused() const
 
 void GameModel::setPaused( bool value )
 {
-	if( m_showMessageWindow && !value )
+	if ( m_showMessageWindow && !value )
 	{
 		return;
 	}
@@ -870,7 +864,7 @@ bool GameModel::getNormalSpeed() const
 
 void GameModel::setNormalSpeed( bool value )
 {
-	if( value )
+	if ( value )
 	{
 		setGameSpeed( GameSpeed::Normal );
 	}
@@ -883,7 +877,7 @@ bool GameModel::getFastSpeed() const
 
 void GameModel::setFastSpeed( bool value )
 {
-	if( value )
+	if ( value )
 	{
 		setGameSpeed( GameSpeed::Fast );
 	}
@@ -1198,7 +1192,7 @@ void GameModel::OnCmdBack( BaseComponent* param )
 void GameModel::CmdRightCommandButton( BaseComponent* param )
 {
 	QString cmd( param->ToString().Str() );
-	
+
 	if ( cmd == "Population" )
 	{
 		setShowPopulation( true );
@@ -1329,7 +1323,6 @@ const NoesisApp::DelegateCommand* GameModel::GetCmdRightCommandButton() const
 	return &_cmdRightCommandButton;
 }
 
-
 void GameModel::OnCmdSimple( BaseComponent* param )
 {
 	Selection::getInstance().setAction( param->ToString().Str() );
@@ -1342,7 +1335,7 @@ void GameModel::onCloseWindowCmd( BaseComponent* param )
 
 void GameModel::onOpenGnomeDetailsCmd( BaseComponent* param )
 {
-	if( param )
+	if ( param )
 	{
 		QString qParam( param->ToString().Str() );
 		m_proxy->requestCreatureUpdate( qParam.toUInt() );
@@ -1363,7 +1356,7 @@ void GameModel::setShownInfo( ShownInfo info )
 {
 	m_shownInfo = info;
 
-	if( m_shownInfo != ShownInfo::CreatureInfo )
+	if ( m_shownInfo != ShownInfo::CreatureInfo )
 	{
 		m_proxy->requestCreatureUpdate( 0 );
 	}
@@ -1378,14 +1371,13 @@ void GameModel::setShownInfo( ShownInfo info )
 	OnPropertyChanged( "ShowNeighbors" );
 	OnPropertyChanged( "ShowMilitary" );
 	OnPropertyChanged( "ShowInventory" );
-	
+
 	OnPropertyChanged( "ShowMessage" );
 }
 
-
 const char* GameModel::getShowMessage() const
 {
-	if( m_showMessageWindow && m_shownInfo == ShownInfo::None )
+	if ( m_showMessageWindow && m_shownInfo == ShownInfo::None )
 	{
 		return "Visible";
 	}
@@ -1394,16 +1386,16 @@ const char* GameModel::getShowMessage() const
 
 const char* GameModel::getShowMessageButtonOk() const
 {
-	if( m_showMessageButtonOk )
+	if ( m_showMessageButtonOk )
 	{
 		return "Visible";
 	}
 	return "Hidden";
 }
-	
+
 const char* GameModel::getShowMessageButtonYesNo() const
 {
-	if( m_showMessageButtonYesNo )
+	if ( m_showMessageButtonYesNo )
 	{
 		return "Visible";
 	}
@@ -1423,16 +1415,16 @@ const char* GameModel::getMessageText() const
 void GameModel::onMessageButtonCmd( BaseComponent* param )
 {
 	qDebug() << "GameModel::onMessageButtonCmd";
-	if( param )
+	if ( param )
 	{
 		QString qParam = param->ToString().Str();
 		qDebug() << qParam;
-		if( qParam != "ok" )
+		if ( qParam != "ok" )
 		{
 			m_proxy->sendEventAnswer( m_messageID, qParam == "yes" );
 		}
 		m_showMessageWindow = false;
-		if( !m_messageQueue.isEmpty() )
+		if ( !m_messageQueue.isEmpty() )
 		{
 			auto gme = m_messageQueue.takeFirst();
 			qDebug() << gme.id << gme.title << gme.msg << gme.pause << gme.yesno;
@@ -1444,25 +1436,25 @@ void GameModel::onMessageButtonCmd( BaseComponent* param )
 
 void GameModel::eventMessage( unsigned int id, QString title, QString msg, bool pause, bool yesno )
 {
-	if( m_showMessageWindow )
+	if ( m_showMessageWindow )
 	{
 		m_messageQueue.append( { id, title, msg, pause, yesno } );
 	}
 	else
 	{
-		m_messageID = id;
-		m_messageHeader = title.toStdString().c_str();
-		m_messageText = msg.toStdString().c_str();
+		m_messageID         = id;
+		m_messageHeader     = title.toStdString().c_str();
+		m_messageText       = msg.toStdString().c_str();
 		m_showMessageWindow = true;
 
-		m_showMessageButtonOk = !yesno;
+		m_showMessageButtonOk    = !yesno;
 		m_showMessageButtonYesNo = yesno;
 
-		if( pause )
+		if ( pause )
 		{
 			setPaused( true );
 		}
-		
+
 		OnPropertyChanged( "ShowMessageButtonOk" );
 		OnPropertyChanged( "ShowMessageButtonYesNo" );
 		OnPropertyChanged( "MessageText" );
@@ -1517,7 +1509,7 @@ NS_IMPLEMENT_REFLECTION( GameModel, "IngnomiaGUI.GameModel" )
 	NsProp( "ShowNeighbors", &GameModel::getShowNeighbors );
 	NsProp( "ShowMilitary", &GameModel::getShowMilitary );
 	NsProp( "ShowInventory", &GameModel::getShowInventory );
-	
+
 	NsProp( "ShowMessage", &GameModel::getShowMessage );
 	NsProp( "ShowMessageButtonOk", &GameModel::getShowMessageButtonOk );
 	NsProp( "ShowMessageButtonYesNo", &GameModel::getShowMessageButtonYesNo );

--- a/src/gui/xaml/PopulationModel.cpp
+++ b/src/gui/xaml/PopulationModel.cpp
@@ -55,10 +55,10 @@ GnomeSkill::GnomeSkill( const GuiSkillInfo& skill, unsigned int gnomeID, Populat
 	m_gnomeID( gnomeID ),
 	m_proxy( proxy )
 {
-	m_name      = skill.name.toStdString().c_str();
-	m_level	= QString::number( skill.level ).toStdString().c_str();
-	m_checked   = skill.active;
-	m_color = skill.color.toStdString().c_str();
+	m_name    = skill.name.toStdString().c_str();
+	m_level   = QString::number( skill.level ).toStdString().c_str();
+	m_checked = skill.active;
+	m_color   = skill.color.toStdString().c_str();
 	m_skillID = skill.sid.toStdString().c_str();
 }
 
@@ -71,7 +71,6 @@ const char* GnomeSkill::GetID() const
 {
 	return m_skillID.Str();
 }
-
 
 const char* GnomeSkill::GetLevel() const
 {
@@ -86,7 +85,7 @@ bool GnomeSkill::GetChecked() const
 void GnomeSkill::SetChecked( bool value )
 {
 	m_checked = value;
-	if( m_proxy )
+	if ( m_proxy )
 	{
 		m_proxy->setSkillActive( m_gnomeID, m_skillID.Str(), value );
 	}
@@ -101,23 +100,23 @@ const char* GnomeSkill::GetColor() const
 GnomeRow::GnomeRow( const GuiGnomeInfo& gnome, Noesis::Ptr<Noesis::ObservableCollection<ProfItem>> professions, PopulationProxy* proxy ) :
 	m_proxy( proxy )
 {
-	m_id        = gnome.id;
-	m_idString  = QString::number( gnome.id ).toStdString().c_str();
-	m_name      = gnome.name.toStdString().c_str();
+	m_id             = gnome.id;
+	m_idString       = QString::number( gnome.id ).toStdString().c_str();
+	m_name           = gnome.name.toStdString().c_str();
 	m_professionName = gnome.profession;
 
 	m_skills = *new ObservableCollection<GnomeSkill>();
 
-	for( const auto& skill : gnome.skills )
+	for ( const auto& skill : gnome.skills )
 	{
 		m_skills->Add( MakePtr<GnomeSkill>( skill, m_id, proxy ) );
 	}
 
 	m_professions = professions;
 
-	for( int i = 0; i < m_professions->Count(); ++i )
+	for ( int i = 0; i < m_professions->Count(); ++i )
 	{
-		if( m_professions->Get( i )->GetName() == gnome.profession )
+		if ( m_professions->Get( i )->GetName() == gnome.profession )
 		{
 			SetProfession( m_professions->Get( i ) );
 			break;
@@ -127,11 +126,11 @@ GnomeRow::GnomeRow( const GuiGnomeInfo& gnome, Noesis::Ptr<Noesis::ObservableCol
 
 void GnomeRow::updateProfessionList( Noesis::Ptr<Noesis::ObservableCollection<ProfItem>> professions )
 {
-	m_professions = professions;
+	m_professions        = professions;
 	m_selectedProfession = nullptr;
-	for( int i = 0; i < m_professions->Count(); ++i )
+	for ( int i = 0; i < m_professions->Count(); ++i )
 	{
-		if( m_professions->Get( i )->GetName() == m_professionName )
+		if ( m_professions->Get( i )->GetName() == m_professionName )
 		{
 			SetProfession( m_professions->Get( i ) );
 			break;
@@ -157,7 +156,7 @@ Noesis::ObservableCollection<ProfItem>* GnomeRow::GetProfessions() const
 {
 	return m_professions;
 }
-	
+
 void GnomeRow::SetProfession( ProfItem* item )
 {
 	if ( item && m_selectedProfession != item )
@@ -173,7 +172,6 @@ ProfItem* GnomeRow::GetProfession() const
 {
 	return m_selectedProfession;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 GnomeScheduleEntry::GnomeScheduleEntry( unsigned int id, int hour, ScheduleActivity activity, PopulationProxy* proxy ) :
@@ -198,7 +196,6 @@ GnomeScheduleEntry::GnomeScheduleEntry( unsigned int id, int hour, ScheduleActiv
 			break;
 	}
 	m_setHourCmd.SetExecuteFunc( MakeDelegate( this, &GnomeScheduleEntry::onSetHourCmd ) );
-
 }
 
 const char* GnomeScheduleEntry::GetActivity() const
@@ -211,23 +208,21 @@ void GnomeScheduleEntry::onSetHourCmd( BaseComponent* param )
 	m_proxy->setSchedule( m_id, m_hour, m_activity );
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-GnomeScheduleRow::GnomeScheduleRow( const GuiGnomeScheduleInfo& gnome, PopulationProxy* proxy  ) :
+GnomeScheduleRow::GnomeScheduleRow( const GuiGnomeScheduleInfo& gnome, PopulationProxy* proxy ) :
 	m_proxy( proxy )
 {
-	m_id        = gnome.id;
-	m_idString  = QString::number( gnome.id ).toStdString().c_str();
-	m_name      = gnome.name.toStdString().c_str();
+	m_id       = gnome.id;
+	m_idString = QString::number( gnome.id ).toStdString().c_str();
+	m_name     = gnome.name.toStdString().c_str();
 
 	m_schedule = *new ObservableCollection<GnomeScheduleEntry>();
-	int hour = 0;
+	int hour   = 0;
 
-	for( const auto& activity : gnome.schedule )
+	for ( const auto& activity : gnome.schedule )
 	{
 		m_schedule->Add( MakePtr<GnomeScheduleEntry>( m_id, hour++, activity, proxy ) );
 	}
-
 }
 
 const char* GnomeScheduleRow::GetName() const
@@ -240,11 +235,6 @@ const char* GnomeScheduleRow::GetID() const
 	return m_idString.Str();
 }
 
-
-
-
-
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 PopulationModel::PopulationModel()
@@ -252,9 +242,9 @@ PopulationModel::PopulationModel()
 	m_proxy = new PopulationProxy;
 	m_proxy->setParent( this );
 
-	m_gnomes = *new ObservableCollection<GnomeRow>();
-	m_skills = *new ObservableCollection<GnomeSkill>();
-	m_profSkills = *new ObservableCollection<GnomeSkill>();
+	m_gnomes         = *new ObservableCollection<GnomeRow>();
+	m_skills         = *new ObservableCollection<GnomeSkill>();
+	m_profSkills     = *new ObservableCollection<GnomeSkill>();
 	m_scheduleGnomes = *new ObservableCollection<GnomeScheduleRow>();
 
 	m_allGnomesCmd.SetExecuteFunc( MakeDelegate( this, &PopulationModel::onAllGnomesCmd ) );
@@ -271,7 +261,7 @@ PopulationModel::PopulationModel()
 	m_profSkillDownCmd.SetExecuteFunc( MakeDelegate( this, &PopulationModel::onProfSkillDownCmd ) );
 	m_profSkillAddCmd.SetExecuteFunc( MakeDelegate( this, &PopulationModel::onProfSkillAddCmd ) );
 	m_profSkillRemoveCmd.SetExecuteFunc( MakeDelegate( this, &PopulationModel::onProfSkillRemoveCmd ) );
-	
+
 	m_newProfCmd.SetExecuteFunc( MakeDelegate( this, &PopulationModel::onNewProfCmd ) );
 	m_deleteProfCmd.SetExecuteFunc( MakeDelegate( this, &PopulationModel::onDeleteProfCmd ) );
 
@@ -281,16 +271,16 @@ PopulationModel::PopulationModel()
 void PopulationModel::updateProfessionList( const QStringList& professions )
 {
 	m_professions->Clear();
-	for( const auto& prof : professions )
+	for ( const auto& prof : professions )
 	{
 		m_professions->Add( MakePtr<ProfItem>( prof.toStdString().c_str() ) );
 	}
-	if( m_professions->Count() > 0 )
+	if ( m_professions->Count() > 0 )
 	{
 		SetProfession( m_professions->Get( 0 ) );
 	}
 
-	for( int i = 0; i < m_gnomes->Count(); ++i )
+	for ( int i = 0; i < m_gnomes->Count(); ++i )
 	{
 		m_gnomes->Get( i )->updateProfessionList( m_professions );
 	}
@@ -302,17 +292,17 @@ void PopulationModel::updateInfo( const GuiPopulationInfo& info )
 {
 	m_gnomes->Clear();
 
-	for( const auto& gnome : info.gnomes )
+	for ( const auto& gnome : info.gnomes )
 	{
 		m_gnomes->Add( MakePtr<GnomeRow>( gnome, m_professions, m_proxy ) );
 	}
 
-	if( m_skills->Count() == 0 )
+	if ( m_skills->Count() == 0 )
 	{
-		if( info.gnomes.size() )
+		if ( info.gnomes.size() )
 		{
 			auto& first = info.gnomes.first();
-			for( const auto& skill : first.skills )
+			for ( const auto& skill : first.skills )
 			{
 				m_skills->Add( MakePtr<GnomeSkill>( skill, 0, m_proxy ) );
 			}
@@ -325,10 +315,10 @@ void PopulationModel::updateInfo( const GuiPopulationInfo& info )
 
 void PopulationModel::updateSingleGnome( const GuiGnomeInfo& gnome )
 {
-	for( int i = 0; i < m_gnomes->Count(); ++i )
+	for ( int i = 0; i < m_gnomes->Count(); ++i )
 	{
 		auto info = m_gnomes->Get( i );
-		if( info->gnomeID() == gnome.id )
+		if ( info->gnomeID() == gnome.id )
 		{
 			m_gnomes->RemoveAt( i );
 			m_gnomes->Insert( i, MakePtr<GnomeRow>( gnome, m_professions, m_proxy ) );
@@ -337,7 +327,6 @@ void PopulationModel::updateSingleGnome( const GuiGnomeInfo& gnome )
 		}
 	}
 }
-
 
 void PopulationModel::onAllGnomesCmd( BaseComponent* param )
 {
@@ -349,15 +338,14 @@ void PopulationModel::onRemoveAllGnomesCmd( BaseComponent* param )
 	m_proxy->setSkillForAllGnomes( param->ToString().Str(), false );
 }
 
-
 void PopulationModel::onAllSkillsCmd( BaseComponent* param )
 {
-	m_proxy->setAllSkillsForGnome( QString(param->ToString().Str() ).toUInt(), true );
+	m_proxy->setAllSkillsForGnome( QString( param->ToString().Str() ).toUInt(), true );
 }
 
 void PopulationModel::onRemoveAllSkillsCmd( BaseComponent* param )
 {
-	m_proxy->setAllSkillsForGnome( QString(param->ToString().Str() ).toUInt(), false );
+	m_proxy->setAllSkillsForGnome( QString( param->ToString().Str() ).toUInt(), false );
 }
 
 void PopulationModel::onSortCmd( BaseComponent* param )
@@ -370,12 +358,12 @@ void PopulationModel::onSortCmd( BaseComponent* param )
 void PopulationModel::onPageCmd( BaseComponent* param )
 {
 	m_state = PopState::Skills;
-	if( param->ToString() == "Schedule" )
+	if ( param->ToString() == "Schedule" )
 	{
 		m_state = PopState::Schedule;
 		m_proxy->requestSchedules();
 	}
-	if( param->ToString() == "ProfEdit" )
+	if ( param->ToString() == "ProfEdit" )
 	{
 		m_state = PopState::ProfEdit;
 		//m_proxy->requestProfessions();
@@ -388,16 +376,16 @@ void PopulationModel::onPageCmd( BaseComponent* param )
 
 const char* PopulationModel::GetShowSkills() const
 {
-	if( m_state == PopState::Skills )
+	if ( m_state == PopState::Skills )
 	{
 		return "Visible";
 	}
 	return "Hidden";
 }
-	
+
 const char* PopulationModel::GetShowSchedule() const
 {
-	if( m_state == PopState::Schedule )
+	if ( m_state == PopState::Schedule )
 	{
 		return "Visible";
 	}
@@ -406,7 +394,7 @@ const char* PopulationModel::GetShowSchedule() const
 
 const char* PopulationModel::GetShowProfEdit() const
 {
-	if( m_state == PopState::ProfEdit )
+	if ( m_state == PopState::ProfEdit )
 	{
 		return "Visible";
 	}
@@ -418,7 +406,7 @@ void PopulationModel::updateSchedules( const GuiScheduleInfo& info )
 	qDebug() << "PopulationModel::updateSchedules";
 	m_scheduleGnomes->Clear();
 
-	for( const auto& gnome : info.schedules )
+	for ( const auto& gnome : info.schedules )
 	{
 		m_scheduleGnomes->Add( MakePtr<GnomeScheduleRow>( gnome, m_proxy ) );
 	}
@@ -427,10 +415,10 @@ void PopulationModel::updateSchedules( const GuiScheduleInfo& info )
 
 void PopulationModel::updateScheduleSingleGnome( const GuiGnomeScheduleInfo& gnome )
 {
-	for( int i = 0; i < m_scheduleGnomes->Count(); ++i )
+	for ( int i = 0; i < m_scheduleGnomes->Count(); ++i )
 	{
 		auto info = m_scheduleGnomes->Get( i );
-		if( info->gnomeID() == gnome.id )
+		if ( info->gnomeID() == gnome.id )
 		{
 			m_scheduleGnomes->RemoveAt( i );
 			m_scheduleGnomes->Insert( i, MakePtr<GnomeScheduleRow>( gnome, m_proxy ) );
@@ -443,10 +431,14 @@ void PopulationModel::updateScheduleSingleGnome( const GuiGnomeScheduleInfo& gno
 void PopulationModel::onSetActivityCmd( BaseComponent* param )
 {
 	QString qParam = param->ToString().Str();
-	if( qParam == "Eat" ) m_scheduleActivity = ScheduleActivity::Eat;
-	else if( qParam == "Sleep" ) m_scheduleActivity = ScheduleActivity::Sleep;
-	else if( qParam == "Train" ) m_scheduleActivity = ScheduleActivity::Training;
-	else m_scheduleActivity = ScheduleActivity::None;
+	if ( qParam == "Eat" )
+		m_scheduleActivity = ScheduleActivity::Eat;
+	else if ( qParam == "Sleep" )
+		m_scheduleActivity = ScheduleActivity::Sleep;
+	else if ( qParam == "Train" )
+		m_scheduleActivity = ScheduleActivity::Training;
+	else
+		m_scheduleActivity = ScheduleActivity::None;
 
 	m_proxy->setCurrentActivity( m_scheduleActivity );
 
@@ -455,7 +447,7 @@ void PopulationModel::onSetActivityCmd( BaseComponent* param )
 
 const char* PopulationModel::GetScheduleActivity() const
 {
-	switch( m_scheduleActivity )
+	switch ( m_scheduleActivity )
 	{
 		case ScheduleActivity::Eat:
 			return "E";
@@ -485,7 +477,7 @@ Noesis::ObservableCollection<ProfItem>* PopulationModel::GetProfessions() const
 {
 	return m_professions;
 }
-	
+
 void PopulationModel::SetProfession( ProfItem* item )
 {
 	if ( item && m_selectedProfession != item )
@@ -494,7 +486,7 @@ void PopulationModel::SetProfession( ProfItem* item )
 		m_proxy->requestSkills( m_selectedProfession->GetName() );
 
 		m_lockProfessionEdit = ( item->GetName() == QString( "Gnomad" ) );
-		
+
 		m_profName = item->GetName();
 
 		OnPropertyChanged( "Profession" );
@@ -511,7 +503,7 @@ void PopulationModel::updateProfessionSkills( const QString profession, const QL
 {
 	m_profSkills->Clear();
 
-	for( const auto& skill : skills )
+	for ( const auto& skill : skills )
 	{
 		m_profSkills->Add( MakePtr<GnomeSkill>( skill, 0, m_proxy ) );
 	}
@@ -521,13 +513,14 @@ void PopulationModel::updateProfessionSkills( const QString profession, const QL
 
 void PopulationModel::onProfSkillUpCmd( BaseComponent* param )
 {
-	if( m_lockProfessionEdit ) return;
-	if( param )
+	if ( m_lockProfessionEdit )
+		return;
+	if ( param )
 	{
 		Noesis::String skillID = param->ToString();
-		for( int i = 1; i < m_profSkills->Count(); ++i )
+		for ( int i = 1; i < m_profSkills->Count(); ++i )
 		{
-			if( m_profSkills->Get( i )->GetID() == skillID )
+			if ( m_profSkills->Get( i )->GetID() == skillID )
 			{
 				m_profSkills->Move( i, i - 1 );
 				break;
@@ -539,13 +532,14 @@ void PopulationModel::onProfSkillUpCmd( BaseComponent* param )
 
 void PopulationModel::onProfSkillDownCmd( BaseComponent* param )
 {
-	if( m_lockProfessionEdit ) return;
-	if( param )
+	if ( m_lockProfessionEdit )
+		return;
+	if ( param )
 	{
 		Noesis::String skillID = param->ToString();
-		for( int i = 0; i < m_profSkills->Count() - 1; ++i )
+		for ( int i = 0; i < m_profSkills->Count() - 1; ++i )
 		{
-			if( m_profSkills->Get( i )->GetID() == skillID )
+			if ( m_profSkills->Get( i )->GetID() == skillID )
 			{
 				m_profSkills->Move( i, i + 1 );
 				break;
@@ -557,23 +551,24 @@ void PopulationModel::onProfSkillDownCmd( BaseComponent* param )
 
 void PopulationModel::onProfSkillAddCmd( BaseComponent* param )
 {
-	if( m_lockProfessionEdit ) return;
-	if( param )
+	if ( m_lockProfessionEdit )
+		return;
+	if ( param )
 	{
 		Noesis::String skillID = param->ToString();
-		for( int i = 0; i < m_profSkills->Count(); ++i )
+		for ( int i = 0; i < m_profSkills->Count(); ++i )
 		{
-			if( m_profSkills->Get( i )->GetID() == skillID )
+			if ( m_profSkills->Get( i )->GetID() == skillID )
 			{
 				return;
 			}
 		}
-		for( int i = 0; i < m_skills->Count(); ++i )
+		for ( int i = 0; i < m_skills->Count(); ++i )
 		{
-			if( m_skills->Get( i )->GetID() == skillID )
+			if ( m_skills->Get( i )->GetID() == skillID )
 			{
 				GuiSkillInfo gsi;
-				gsi.sid = skillID.Str();
+				gsi.sid  = skillID.Str();
 				gsi.name = m_skills->Get( i )->GetName();
 				m_profSkills->Add( MakePtr<GnomeSkill>( gsi, 0, m_proxy ) );
 				OnPropertyChanged( "ProfSkills" );
@@ -586,13 +581,14 @@ void PopulationModel::onProfSkillAddCmd( BaseComponent* param )
 
 void PopulationModel::onProfSkillRemoveCmd( BaseComponent* param )
 {
-	if( m_lockProfessionEdit ) return;
-	if( param )
+	if ( m_lockProfessionEdit )
+		return;
+	if ( param )
 	{
 		Noesis::String skillID = param->ToString();
-		for( int i = 0; i < m_profSkills->Count(); ++i )
+		for ( int i = 0; i < m_profSkills->Count(); ++i )
 		{
-			if( m_profSkills->Get( i )->GetID() == skillID )
+			if ( m_profSkills->Get( i )->GetID() == skillID )
 			{
 				m_profSkills->RemoveAt( i );
 				OnPropertyChanged( "ProfSkills" );
@@ -605,10 +601,10 @@ void PopulationModel::onProfSkillRemoveCmd( BaseComponent* param )
 
 void PopulationModel::sendModifiedProfession()
 {
-	if( m_selectedProfession )
+	if ( m_selectedProfession )
 	{
 		QStringList skills;
-		for( int i = 0; i < m_profSkills->Count(); ++i )
+		for ( int i = 0; i < m_profSkills->Count(); ++i )
 		{
 			skills.append( m_profSkills->Get( i )->GetID() );
 		}
@@ -640,30 +636,29 @@ const char* PopulationModel::GetProfName() const
 
 void PopulationModel::SetProfName( const char* value )
 {
-	if( strcmp( value, m_profName.Str() ) != 0 )
+	if ( strcmp( value, m_profName.Str() ) != 0 )
 	{
-		QString newName = value; 
-	
+		QString newName = value;
+
 		bool nameExists = false;
 
-		for( int i = 0; i < m_professions->Count(); ++i )
+		for ( int i = 0; i < m_professions->Count(); ++i )
 		{
-			if( m_professions->Get( i )->GetName() == newName )
+			if ( m_professions->Get( i )->GetName() == newName )
 			{
 				nameExists = true;
 				break;
 			}
 		}
 		m_profName = value;
-	
-		if( newName.length() > 3 && !nameExists )
+
+		if ( newName.length() > 3 && !nameExists )
 		{
 			sendModifiedProfession();
 		}
 		OnPropertyChanged( "ProfName" );
 	}
 }
-
 
 void PopulationModel::onNewProfCmd( BaseComponent* param )
 {
@@ -672,7 +667,7 @@ void PopulationModel::onNewProfCmd( BaseComponent* param )
 
 void PopulationModel::onDeleteProfCmd( BaseComponent* param )
 {
-	if( m_selectedProfession )
+	if ( m_selectedProfession )
 	{
 		QString name = m_selectedProfession->GetName();
 		m_proxy->deleteProfession( name );
@@ -681,9 +676,9 @@ void PopulationModel::onDeleteProfCmd( BaseComponent* param )
 
 void PopulationModel::selectEditProfession( const QString name )
 {
-	for( int i = 0; i < m_professions->Count(); ++i )
+	for ( int i = 0; i < m_professions->Count(); ++i )
 	{
-		if( m_professions->Get( i )->GetName() == name )
+		if ( m_professions->Get( i )->GetName() == name )
 		{
 			SetProfession( m_professions->Get( i ) );
 			break;
@@ -693,7 +688,6 @@ void PopulationModel::selectEditProfession( const QString name )
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 NS_BEGIN_COLD_REGION
-
 
 NS_IMPLEMENT_REFLECTION( ProfItem )
 {
@@ -756,7 +750,6 @@ NS_IMPLEMENT_REFLECTION( GnomeScheduleRow )
 	NsProp( "Name", &GnomeScheduleRow::GetName );
 	NsProp( "GnomeID", &GnomeScheduleRow::GetID );
 	NsProp( "Schedule", &GnomeScheduleRow::GetSchedule );
-	
 }
 
 NS_IMPLEMENT_REFLECTION( GnomeScheduleEntry )

--- a/src/gui/xaml/PopulationModel.h
+++ b/src/gui/xaml/PopulationModel.h
@@ -29,7 +29,6 @@
 #include <NsCore/String.h>
 #include <NsGui/Collection.h>
 
-
 #include <QString>
 
 class PopulationProxy;
@@ -100,7 +99,10 @@ public:
 	const char* GetName() const;
 	const char* GetID() const;
 
-	unsigned int gnomeID() { return m_id; }
+	unsigned int gnomeID()
+	{
+		return m_id;
+	}
 
 	void updateProfessionList( Noesis::Ptr<Noesis::ObservableCollection<ProfItem>> professions );
 
@@ -122,12 +124,10 @@ private:
 	Noesis::Ptr<Noesis::ObservableCollection<ProfItem>> m_professions;
 	ProfItem* m_selectedProfession = nullptr;
 
-
 	PopulationProxy* m_proxy = nullptr;
 
 	NS_DECLARE_REFLECTION( GnomeRow, NoesisApp::NotifyPropertyChangedBase )
 };
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 class GnomeScheduleEntry : public NoesisApp::NotifyPropertyChangedBase
@@ -138,12 +138,12 @@ public:
 	PopulationProxy* m_proxy = nullptr;
 
 	const char* GetActivity() const;
-	
+
 private:
 	ScheduleActivity m_activity;
 	Noesis::String m_activityString;
 	unsigned int m_id = 0;
-	int m_hour = 0;
+	int m_hour        = 0;
 
 	void onSetHourCmd( BaseComponent* param );
 	const NoesisApp::DelegateCommand* GetSetHourCmd() const
@@ -152,7 +152,7 @@ private:
 	}
 	NoesisApp::DelegateCommand m_setHourCmd;
 
-NS_DECLARE_REFLECTION( GnomeScheduleEntry, NoesisApp::NotifyPropertyChangedBase )
+	NS_DECLARE_REFLECTION( GnomeScheduleEntry, NoesisApp::NotifyPropertyChangedBase )
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -164,7 +164,10 @@ public:
 	const char* GetName() const;
 	const char* GetID() const;
 
-	unsigned int gnomeID() { return m_id; }
+	unsigned int gnomeID()
+	{
+		return m_id;
+	}
 
 private:
 	Noesis::String m_name;
@@ -220,7 +223,6 @@ private:
 		return m_profSkills;
 	}
 	Noesis::Ptr<Noesis::ObservableCollection<GnomeSkill>> m_profSkills;
-
 
 	void onAllGnomesCmd( BaseComponent* param );
 	const NoesisApp::DelegateCommand* GetAllGnomesCmd() const
@@ -301,7 +303,6 @@ private:
 	}
 	NoesisApp::DelegateCommand m_setHoursForAllCmd;
 
-
 	Noesis::ObservableCollection<ProfItem>* GetProfessions() const;
 	void SetProfession( ProfItem* item );
 	ProfItem* GetProfession() const;
@@ -341,7 +342,6 @@ private:
 	const char* GetProfName() const;
 	void SetProfName( const char* value );
 
-
 	void onNewProfCmd( BaseComponent* param );
 	const NoesisApp::DelegateCommand* GetNewProfCmd() const
 	{
@@ -355,7 +355,6 @@ private:
 		return &m_deleteProfCmd;
 	}
 	NoesisApp::DelegateCommand m_deleteProfCmd;
-
 
 	NS_DECLARE_REFLECTION( PopulationModel, NotifyPropertyChangedBase )
 };

--- a/src/gui/xaml/agriculturemodel.cpp
+++ b/src/gui/xaml/agriculturemodel.cpp
@@ -20,9 +20,9 @@
 #include "../../base/gamestate.h"
 #include "../../base/global.h"
 #include "../../base/util.h"
-#include "agricultureproxy.h"
 #include "../../gfx/spritefactory.h"
 #include "../strings.h"
+#include "agricultureproxy.h"
 
 #include <NsApp/Application.h>
 #include <NsCore/Log.h>
@@ -179,34 +179,33 @@ Noesis::ObservableCollection<PlantSelectEntry>* PlantSelectRow::GetPlants() cons
 }
 #pragma endregion Plants
 
-
 #pragma region Pasture
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 PastureAnimalEntry::PastureAnimalEntry( const GuiPastureAnimal& animal, AgricultureProxy* proxy ) :
 	m_proxy( proxy )
 {
-	
+
 	m_sid       = animal.animalID.toStdString().c_str();
 	m_id        = animal.id;
 	m_toButcher = animal.toButcher;
-	m_isYoung = animal.isYoung;
-	m_gender = animal.gender;
+	m_isYoung   = animal.isYoung;
+	m_gender    = animal.gender;
 
 	QString qName;
-	if( m_gender == Gender::MALE )
+	if ( m_gender == Gender::MALE )
 	{
 		qName += "Male ";
 	}
-	else if( m_gender == Gender::FEMALE )
+	else if ( m_gender == Gender::FEMALE )
 	{
 		qName += "Female ";
 	}
 	qName += animal.name;
-	if( m_isYoung )
+	if ( m_isYoung )
 	{
 		qName += " (young)";
 	}
-	m_name      = qName.toStdString().c_str();
+	m_name = qName.toStdString().c_str();
 }
 
 const char* PastureAnimalEntry::GetName() const
@@ -224,7 +223,7 @@ void PastureAnimalEntry::SetButchering( bool value )
 	if ( m_toButcher != value )
 	{
 		m_toButcher = value;
-		if( m_proxy )
+		if ( m_proxy )
 		{
 			m_proxy->setButchering( m_id, value );
 		}
@@ -238,10 +237,10 @@ FoodSelectEntry::FoodSelectEntry( const GuiPastureFoodItem& food, AgriculturePro
 	m_proxy( proxy )
 {
 	m_name = food.name.toStdString().c_str();
-	
-	m_itemSID  = food.itemSID;
+
+	m_itemSID     = food.itemSID;
 	m_materialSID = food.materialSID;
-	m_checked = food.checked;
+	m_checked     = food.checked;
 
 	auto pm = Util::smallPixmap( Global::sf().createSprite( food.itemSID, { food.materialSID } ), GameState::seasonString, 0 );
 
@@ -261,10 +260,10 @@ bool FoodSelectEntry::getChecked() const
 {
 	return m_checked;
 }
-	
+
 void FoodSelectEntry::setChecked( bool value )
 {
-	if( m_checked != value )
+	if ( m_checked != value )
 	{
 		m_checked = value;
 		m_proxy->setFoodItemChecked( m_itemSID, m_materialSID, m_checked );
@@ -287,7 +286,6 @@ Noesis::ObservableCollection<FoodSelectEntry>* FoodSelectRow::GetFoods() const
 	return m_entries;
 }
 #pragma endregion PastureFood
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -422,7 +420,7 @@ void AgricultureModel::updateStandardInfo( unsigned int ID, AgriType type, QStri
 	}
 	if ( !isSame )
 	{
-		m_manageWindow = false;
+		m_manageWindow  = false;
 		m_productSelect = false;
 
 		m_pastureAnimals->Clear();
@@ -512,7 +510,6 @@ void AgricultureModel::updatePastureInfo( const GuiPastureInfo& info )
 	m_hayStatus  = ( QString::number( info.hayCurrent ) + "/" ).toStdString().c_str();
 	m_maxHay     = ( QString::number( info.hayMax ) ).toStdString().c_str();
 
-
 	m_pastureAnimals->Clear();
 
 	for ( const auto& pa : info.animals )
@@ -550,8 +547,8 @@ void AgricultureModel::updatePastureInfo( const GuiPastureInfo& info )
 	OnPropertyChanged( "Title" );
 
 	m_foodRows->Clear();
-	if( !info.food.isEmpty() )
-	{	
+	if ( !info.food.isEmpty() )
+	{
 		int foodDone = 0;
 		while ( foodDone < info.food.size() )
 		{
@@ -978,8 +975,8 @@ void AgricultureModel::onManageAnimals( BaseComponent* param )
 {
 	m_proxy->requestPastureAnimalInfo();
 
-	m_manageWindow  = true;
-	m_productSelect = false;
+	m_manageWindow      = true;
+	m_productSelect     = false;
 	m_pastureFoodSelect = false;
 	OnPropertyChanged( "ShowManageWindow" );
 	OnPropertyChanged( "ShowPasture" );
@@ -987,8 +984,8 @@ void AgricultureModel::onManageAnimals( BaseComponent* param )
 
 void AgricultureModel::onManageAnimalsBack( BaseComponent* param )
 {
-	m_manageWindow  = false;
-	m_productSelect = false;
+	m_manageWindow      = false;
+	m_productSelect     = false;
 	m_pastureFoodSelect = false;
 	OnPropertyChanged( "ShowManageWindow" );
 	OnPropertyChanged( "ShowPasture" );
@@ -1005,14 +1002,14 @@ const char* AgricultureModel::GetManageWindowVis() const
 
 void AgricultureModel::onShowPastureFood( BaseComponent* param )
 {
-	if( param )
+	if ( param )
 	{
 		QString qParam = param->ToString().Str();
-		if( qParam == "Back" )
+		if ( qParam == "Back" )
 		{
 			m_pastureFoodSelect = false;
 		}
-		else if( qParam == "Show" )
+		else if ( qParam == "Show" )
 		{
 			m_proxy->requestPastureFoodInfo();
 			m_pastureFoodSelect = true;
@@ -1039,19 +1036,18 @@ const char* AgricultureModel::GetMaxHay() const
 
 void AgricultureModel::SetMaxHay( const char* value )
 {
-	if( value )
+	if ( value )
 	{
 		QString qValue = value;
 		bool ok;
 		int val = qValue.toInt( &ok );
-		if( ok )
+		if ( ok )
 		{
 			qDebug() << "set max hay to: " << value;
 			m_maxHay = value;
 		}
 	}
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 NS_BEGIN_COLD_REGION

--- a/src/gui/xaml/militarymodel.cpp
+++ b/src/gui/xaml/militarymodel.cpp
@@ -16,6 +16,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "militarymodel.h"
+
 #include "militaryproxy.h"
 
 #include <NsApp/Application.h>
@@ -43,10 +44,9 @@ SquadPriority::SquadPriority( const GuiTargetPriority& prio, unsigned int squadI
 	m_moveDownCmd.SetExecuteFunc( MakeDelegate( this, &SquadPriority::onMoveDownCmd ) );
 }
 
-
 void SquadPriority::setIgnore( bool value )
 {
-	if( value && m_attitude != MilAttitude::_IGNORE )
+	if ( value && m_attitude != MilAttitude::_IGNORE )
 	{
 		m_attitude = MilAttitude::_IGNORE;
 		m_proxy->setAttitude( m_squadID, m_idString.Str(), m_attitude );
@@ -59,7 +59,7 @@ void SquadPriority::setIgnore( bool value )
 
 void SquadPriority::setAvoid( bool value )
 {
-	if( value && m_attitude != MilAttitude::AVOID )
+	if ( value && m_attitude != MilAttitude::AVOID )
 	{
 		m_attitude = MilAttitude::AVOID;
 		m_proxy->setAttitude( m_squadID, m_idString.Str(), m_attitude );
@@ -72,7 +72,7 @@ void SquadPriority::setAvoid( bool value )
 
 void SquadPriority::setAttack( bool value )
 {
-	if( value && m_attitude != MilAttitude::ATTACK )
+	if ( value && m_attitude != MilAttitude::ATTACK )
 	{
 		m_attitude = MilAttitude::ATTACK;
 		m_proxy->setAttitude( m_squadID, m_idString.Str(), m_attitude );
@@ -85,7 +85,7 @@ void SquadPriority::setAttack( bool value )
 
 void SquadPriority::setHunt( bool value )
 {
-	if( value && m_attitude != MilAttitude::HUNT )
+	if ( value && m_attitude != MilAttitude::HUNT )
 	{
 		m_attitude = MilAttitude::HUNT;
 		m_proxy->setAttitude( m_squadID, m_idString.Str(), m_attitude );
@@ -98,7 +98,7 @@ void SquadPriority::setHunt( bool value )
 
 void SquadPriority::onMoveUpCmd( BaseComponent* param )
 {
-	if( param )
+	if ( param )
 	{
 		m_proxy->movePrioUp( m_squadID, param->ToString().Str() );
 	}
@@ -106,7 +106,7 @@ void SquadPriority::onMoveUpCmd( BaseComponent* param )
 
 void SquadPriority::onMoveDownCmd( BaseComponent* param )
 {
-	if( param )
+	if ( param )
 	{
 		m_proxy->movePrioDown( m_squadID, param->ToString().Str() );
 	}
@@ -129,18 +129,16 @@ RoleItem* SquadGnome::getRole() const
 {
 	return m_role;
 }
-	
+
 void SquadGnome::setRole( RoleItem* role )
 {
-	if( m_role != role )
+	if ( m_role != role )
 	{
 		m_role = role;
 		m_proxy->setRole( m_id, role->getID() );
 		OnPropertyChanged( "Role" );
 	}
 }
-
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 SquadItem::SquadItem( const GuiSquad& squad, MilitaryProxy* proxy ) :
@@ -152,13 +150,13 @@ SquadItem::SquadItem( const GuiSquad& squad, MilitaryProxy* proxy ) :
 	m_proxy( proxy )
 {
 	m_gnomes = *new ObservableCollection<SquadGnome>();
-	for( const auto& gnome: squad.gnomes )
+	for ( const auto& gnome : squad.gnomes )
 	{
-		m_gnomes->Add( MakePtr<SquadGnome>( gnome, m_showLeftArrow, m_showRightArrow || ( m_id == 0 ), ( m_id != 0 ),  m_proxy ) );
+		m_gnomes->Add( MakePtr<SquadGnome>( gnome, m_showLeftArrow, m_showRightArrow || ( m_id == 0 ), ( m_id != 0 ), m_proxy ) );
 	}
 
 	m_priorities = *new ObservableCollection<SquadPriority>();
-	for( const auto& prio : squad.priorities )
+	for ( const auto& prio : squad.priorities )
 	{
 		m_priorities->Add( MakePtr<SquadPriority>( prio, squad.id, proxy ) );
 	}
@@ -182,7 +180,7 @@ void SquadItem::onShowConfigCmd( BaseComponent* param )
 void SquadItem::updatePriorities( const QList<GuiTargetPriority>& prios )
 {
 	m_priorities->Clear();
-	for( const auto& prio : prios )
+	for ( const auto& prio : prios )
 	{
 		m_priorities->Add( MakePtr<SquadPriority>( prio, m_id, m_proxy ) );
 	}
@@ -193,16 +191,12 @@ UniformModelMaterial::UniformModelMaterial( QString sid, QString name ) :
 	m_name( name.toStdString().c_str() ),
 	m_sid( sid.toStdString().c_str() )
 {
-
 }
-
-
 
 UniformModelType::UniformModelType( QString sid, QString name ) :
 	m_name( name.toStdString().c_str() ),
 	m_sid( sid.toStdString().c_str() )
 {
-
 }
 
 UniformModelItem::UniformModelItem( const GuiUniformItem& gui, unsigned int roleID, MilitaryProxy* proxy ) :
@@ -213,20 +207,20 @@ UniformModelItem::UniformModelItem( const GuiUniformItem& gui, unsigned int role
 	m_proxy( proxy )
 {
 	m_availableTypes = *new ObservableCollection<UniformModelType>();
-	m_availableMats = *new ObservableCollection<UniformModelMaterial>();
+	m_availableMats  = *new ObservableCollection<UniformModelMaterial>();
 
 	int selectedIndex = -1;
-	int i = -1;
-	for( auto type : gui.possibleTypesForSlot )
+	int i             = -1;
+	for ( auto type : gui.possibleTypesForSlot )
 	{
 		++i;
-		if( type == gui.armorType )
+		if ( type == gui.armorType )
 		{
 			selectedIndex = i;
 		}
 		m_availableTypes->Add( MakePtr<UniformModelType>( type, type ) );
 	}
-	if( selectedIndex != -1 )
+	if ( selectedIndex != -1 )
 	{
 		setSelectedType( m_availableTypes->Get( selectedIndex ) );
 		m_mat = gui.material;
@@ -238,9 +232,9 @@ void UniformModelItem::setSelectedType( UniformModelType* type )
 	if ( m_selectedType != type && type != nullptr )
 	{
 		m_selectedType = type;
-		m_mat = "any";
+		m_mat          = "any";
 		m_proxy->setArmorType( m_roleID, m_sid.Str(), type->sid(), "any" );
-		
+
 		//OnPropertyChanged( "SelectedType" );
 	}
 }
@@ -250,8 +244,8 @@ void UniformModelItem::setSelectedMaterial( UniformModelMaterial* mat )
 	if ( m_selectedMat != mat && mat != nullptr )
 	{
 		m_selectedMat = mat;
-		m_mat = mat->sid();
-		if( m_selectedType )
+		m_mat         = mat->sid();
+		if ( m_selectedType )
 		{
 			m_proxy->setArmorType( m_roleID, m_sid.Str(), m_selectedType->sid(), mat->sid() );
 		}
@@ -263,24 +257,23 @@ void UniformModelItem::setPossibleMats( QStringList mats )
 {
 	m_availableMats->Clear();
 	int selectedMat = -1;
-	
-	for( int i = 0; i < mats.size(); ++i )
+
+	for ( int i = 0; i < mats.size(); ++i )
 	{
 		QString mat = mats[i];
 		m_availableMats->Add( MakePtr<UniformModelMaterial>( mat, mat ) );
-		if( mat == m_mat )
+		if ( mat == m_mat )
 		{
 			selectedMat = i;
 		}
 	}
-	if( selectedMat != -1 )
+	if ( selectedMat != -1 )
 	{
 		m_selectedMat = m_availableMats->Get( selectedMat );
 	}
 	OnPropertyChanged( "AvailableMaterials" );
 	OnPropertyChanged( "SelectedMaterial" );
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 RoleItem::RoleItem( const GuiMilRole& role, MilitaryProxy* proxy ) :
@@ -295,11 +288,10 @@ RoleItem::RoleItem( const GuiMilRole& role, MilitaryProxy* proxy ) :
 
 	m_uniformItems = *new ObservableCollection<UniformModelItem>();
 
-	for( const auto& gui : role.uniform )
+	for ( const auto& gui : role.uniform )
 	{
 		m_uniformItems->Add( MakePtr<UniformModelItem>( gui, m_id, m_proxy ) );
 	}
-
 }
 
 void RoleItem::setName( const char* value )
@@ -317,10 +309,10 @@ void RoleItem::onShowConfigCmd( BaseComponent* param )
 
 void RoleItem::updatePossibleMaterials( QString slot, QStringList mats )
 {
-	for( int i = 0; i < m_uniformItems->Count(); ++i )
+	for ( int i = 0; i < m_uniformItems->Count(); ++i )
 	{
 		auto item = m_uniformItems->Get( i );
-		if( item->sid() == slot )
+		if ( item->sid() == slot )
 		{
 			item->setPossibleMats( mats );
 			break;
@@ -332,18 +324,15 @@ bool RoleItem::GetCivilian() const
 {
 	return m_civilian;
 }
-	
+
 void RoleItem::SetCivilian( bool value )
 {
-	if( m_civilian != value )
+	if ( m_civilian != value )
 	{
 		m_civilian = value;
 		m_proxy->setRoleCivilian( m_id, value );
 	}
 }
-
-
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 MilitaryModel::MilitaryModel()
@@ -360,13 +349,12 @@ MilitaryModel::MilitaryModel()
 	m_removeGnomeFromSquadCmd.SetExecuteFunc( MakeDelegate( this, &MilitaryModel::onRemoveGnomeFromSquadCmd ) );
 	m_moveGnomeLeftCmd.SetExecuteFunc( MakeDelegate( this, &MilitaryModel::onMoveGnomeLeftCmd ) );
 	m_moveGnomeRightCmd.SetExecuteFunc( MakeDelegate( this, &MilitaryModel::onMoveGnomeRightCmd ) );
-	
+
 	m_addRoleCmd.SetExecuteFunc( MakeDelegate( this, &MilitaryModel::onAddRoleCmd ) );
 	m_removeRoleCmd.SetExecuteFunc( MakeDelegate( this, &MilitaryModel::onRemoveRoleCmd ) );
 
-
 	m_squads = *new ObservableCollection<SquadItem>();
-	m_roles = *new ObservableCollection<RoleItem>();
+	m_roles  = *new ObservableCollection<RoleItem>();
 }
 
 const char* MilitaryModel::getShowFirst() const
@@ -377,7 +365,7 @@ const char* MilitaryModel::getShowFirst() const
 	}
 	return "Hidden";
 }
-	
+
 const char* MilitaryModel::getShowSecond() const
 {
 	if ( m_page == MilitaryPage::Second )
@@ -398,11 +386,11 @@ const char* MilitaryModel::getShowThird() const
 
 void MilitaryModel::onPageCmd( BaseComponent* param )
 {
-	if( param->ToString() == "First" )
+	if ( param->ToString() == "First" )
 	{
 		m_page = MilitaryPage::First;
 	}
-	else if( param->ToString() == "Second" )
+	else if ( param->ToString() == "Second" )
 	{
 		m_proxy->requestRoles();
 		m_page = MilitaryPage::Second;
@@ -411,7 +399,7 @@ void MilitaryModel::onPageCmd( BaseComponent* param )
 	{
 		m_page = MilitaryPage::Third;
 	}
-	
+
 	OnPropertyChanged( "ShowFirst" );
 	OnPropertyChanged( "ShowSecond" );
 	OnPropertyChanged( "ShowThird" );
@@ -421,7 +409,7 @@ void MilitaryModel::updateSquads( const QList<GuiSquad>& squads )
 {
 	m_squads->Clear();
 
-	for( const auto& squad : squads )
+	for ( const auto& squad : squads )
 	{
 		m_squads->Add( MakePtr<SquadItem>( squad, m_proxy ) );
 	}
@@ -432,15 +420,15 @@ void MilitaryModel::updateSquads( const QList<GuiSquad>& squads )
 
 void MilitaryModel::updateRoles( const QList<GuiMilRole>& roles )
 {
-	for( int r = 0; r < m_roles->Count(); ++r )
+	for ( int r = 0; r < m_roles->Count(); ++r )
 	{
 		auto roleItem = m_roles->Get( r );
 
-		for( int i = 0; i < m_squads->Count(); ++i )
+		for ( int i = 0; i < m_squads->Count(); ++i )
 		{
-			auto squad = m_squads->Get( i );
+			auto squad  = m_squads->Get( i );
 			auto gnomes = squad->getGnomes();
-			for( int k = 0; k < gnomes->Count(); ++k )
+			for ( int k = 0; k < gnomes->Count(); ++k )
 			{
 				auto gnome = gnomes->Get( k );
 				gnome->nullifyRole();
@@ -450,23 +438,23 @@ void MilitaryModel::updateRoles( const QList<GuiMilRole>& roles )
 
 	m_roles->Clear();
 
-	for( const auto& role : roles )
+	for ( const auto& role : roles )
 	{
 		m_roles->Add( MakePtr<RoleItem>( role, m_proxy ) );
 	}
-	
-	for( int r = 0; r < m_roles->Count(); ++r )
+
+	for ( int r = 0; r < m_roles->Count(); ++r )
 	{
 		auto roleItem = m_roles->Get( r );
 
-		for( int i = 0; i < m_squads->Count(); ++i )
+		for ( int i = 0; i < m_squads->Count(); ++i )
 		{
-			auto squad = m_squads->Get( i );
+			auto squad  = m_squads->Get( i );
 			auto gnomes = squad->getGnomes();
-			for( int k = 0; k < gnomes->Count(); ++k )
+			for ( int k = 0; k < gnomes->Count(); ++k )
 			{
 				auto gnome = gnomes->Get( k );
-				if( gnome->roleID() == roleItem->getID() )
+				if ( gnome->roleID() == roleItem->getID() )
 				{
 					gnome->setRole( roleItem );
 				}
@@ -483,7 +471,7 @@ void MilitaryModel::onAddSquadCmd( BaseComponent* param )
 
 void MilitaryModel::onRemoveSquadCmd( BaseComponent* param )
 {
-	if( param )
+	if ( param )
 	{
 		QString qID( param->ToString().Str() );
 		unsigned int id = qID.toUInt();
@@ -493,7 +481,7 @@ void MilitaryModel::onRemoveSquadCmd( BaseComponent* param )
 
 void MilitaryModel::onMoveSquadLeftCmd( BaseComponent* param )
 {
-	if( param )
+	if ( param )
 	{
 		QString qID( param->ToString().Str() );
 		unsigned int id = qID.toUInt();
@@ -503,7 +491,7 @@ void MilitaryModel::onMoveSquadLeftCmd( BaseComponent* param )
 
 void MilitaryModel::onMoveSquadRightCmd( BaseComponent* param )
 {
-	if( param )
+	if ( param )
 	{
 		QString qID( param->ToString().Str() );
 		unsigned int id = qID.toUInt();
@@ -513,7 +501,7 @@ void MilitaryModel::onMoveSquadRightCmd( BaseComponent* param )
 
 void MilitaryModel::onRemoveGnomeFromSquadCmd( BaseComponent* param )
 {
-	if( param )
+	if ( param )
 	{
 		QString qID( param->ToString().Str() );
 		unsigned int id = qID.toUInt();
@@ -523,7 +511,7 @@ void MilitaryModel::onRemoveGnomeFromSquadCmd( BaseComponent* param )
 
 void MilitaryModel::onMoveGnomeLeftCmd( BaseComponent* param )
 {
-	if( param )
+	if ( param )
 	{
 		QString qID( param->ToString().Str() );
 		unsigned int id = qID.toUInt();
@@ -533,7 +521,7 @@ void MilitaryModel::onMoveGnomeLeftCmd( BaseComponent* param )
 
 void MilitaryModel::onMoveGnomeRightCmd( BaseComponent* param )
 {
-	if( param )
+	if ( param )
 	{
 		QString qID( param->ToString().Str() );
 		unsigned int id = qID.toUInt();
@@ -543,17 +531,16 @@ void MilitaryModel::onMoveGnomeRightCmd( BaseComponent* param )
 
 void MilitaryModel::updatePriorities( unsigned int squadID, const QList<GuiTargetPriority>& priorities )
 {
-	for( int i = 0; i < m_squads->Count(); ++i )
+	for ( int i = 0; i < m_squads->Count(); ++i )
 	{
 		auto squad = m_squads->Get( i );
-		if( squad->getID() == squadID )
+		if ( squad->getID() == squadID )
 		{
 			squad->updatePriorities( priorities );
 			break;
 		}
 	}
 }
-
 
 void MilitaryModel::onAddRoleCmd( BaseComponent* param )
 {
@@ -562,7 +549,7 @@ void MilitaryModel::onAddRoleCmd( BaseComponent* param )
 
 void MilitaryModel::onRemoveRoleCmd( BaseComponent* param )
 {
-	if( param )
+	if ( param )
 	{
 		QString qID( param->ToString().Str() );
 		unsigned int id = qID.toUInt();
@@ -572,9 +559,9 @@ void MilitaryModel::onRemoveRoleCmd( BaseComponent* param )
 
 void MilitaryModel::updatePossibleMaterials( unsigned int roleID, const QString slot, const QStringList mats )
 {
-	for( int i = 0; i < m_roles->Count(); ++i )
+	for ( int i = 0; i < m_roles->Count(); ++i )
 	{
-		if( m_roles->Get( i )->getID() == roleID )
+		if ( m_roles->Get( i )->getID() == roleID )
 		{
 			m_roles->Get( i )->updatePossibleMaterials( slot, mats );
 
@@ -582,7 +569,6 @@ void MilitaryModel::updatePossibleMaterials( unsigned int roleID, const QString 
 		}
 	}
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 NS_BEGIN_COLD_REGION
@@ -625,7 +611,7 @@ NS_IMPLEMENT_REFLECTION( SquadGnome, "IngnomiaGUI.SquadGnome" )
 {
 	NsProp( "ID", &SquadGnome::getIDString );
 	NsProp( "Name", &SquadGnome::getName );
-	
+
 	NsProp( "ShowLeftArrow", &SquadGnome::getShowLeftArrow );
 	NsProp( "ShowRightArrow", &SquadGnome::getShowRightArrow );
 	NsProp( "ShowX", &SquadGnome::getShowX );
@@ -642,7 +628,6 @@ NS_IMPLEMENT_REFLECTION( SquadPriority, "IngnomiaGUI.SquadPriority" )
 	NsProp( "Hunt", &SquadPriority::getHunt, &SquadPriority::setHunt );
 	NsProp( "MoveUpCmd", &SquadPriority::getMoveUpCmd );
 	NsProp( "MoveDownCmd", &SquadPriority::getMoveDownCmd );
-	
 }
 
 NS_IMPLEMENT_REFLECTION( RoleItem, "IngnomiaGUI.RoleItem" )

--- a/src/gui/xaml/militarymodel.h
+++ b/src/gui/xaml/militarymodel.h
@@ -19,8 +19,6 @@
 
 #include "../aggregatormilitary.h"
 
-#include <QString>
-
 #include <NsApp/DelegateCommand.h>
 #include <NsApp/NotifyPropertyChangedBase.h>
 #include <NsCore/Noesis.h>
@@ -30,6 +28,8 @@
 #include <NsCore/ReflectionDeclareEnum.h>
 #include <NsCore/String.h>
 #include <NsGui/Collection.h>
+
+#include <QString>
 
 class MilitaryProxy;
 
@@ -49,26 +49,45 @@ enum class MilitaryPage
 	Third
 };
 
-
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 class SquadPriority final : public NoesisApp::NotifyPropertyChangedBase
 {
 public:
 	SquadPriority( const GuiTargetPriority& prio, unsigned int squadID, MilitaryProxy* proxy );
 
-	const char* getIDString() const { return m_idString.Str(); }
-	const char* getName() const { return m_name.Str(); }
+	const char* getIDString() const
+	{
+		return m_idString.Str();
+	}
+	const char* getName() const
+	{
+		return m_name.Str();
+	}
 
-	QString getID() { return m_idString.Str(); }
+	QString getID()
+	{
+		return m_idString.Str();
+	}
 
-	bool getIgnore() const { return m_attitude == MilAttitude::_IGNORE; }
+	bool getIgnore() const
+	{
+		return m_attitude == MilAttitude::_IGNORE;
+	}
 	void setIgnore( bool value );
-	bool getAvoid() const { return m_attitude == MilAttitude::AVOID; }
+	bool getAvoid() const
+	{
+		return m_attitude == MilAttitude::AVOID;
+	}
 	void setAvoid( bool value );
-	bool getAttack() const { return m_attitude == MilAttitude::ATTACK; }
+	bool getAttack() const
+	{
+		return m_attitude == MilAttitude::ATTACK;
+	}
 	void setAttack( bool value );
-	bool getHunt() const { return m_attitude == MilAttitude::HUNT; }
+	bool getHunt() const
+	{
+		return m_attitude == MilAttitude::HUNT;
+	}
 	void setHunt( bool value );
 
 private:
@@ -92,7 +111,7 @@ private:
 		return &m_moveDownCmd;
 	}
 	NoesisApp::DelegateCommand m_moveDownCmd;
-	
+
 	NS_DECLARE_REFLECTION( SquadPriority, NoesisApp::NotifyPropertyChangedBase )
 };
 
@@ -103,35 +122,59 @@ class SquadGnome final : public NoesisApp::NotifyPropertyChangedBase
 public:
 	SquadGnome( const GuiSquadGnome& gnome, bool showLeft, bool showRight, bool showX, MilitaryProxy* proxy );
 
-	const char* getIDString() const { return m_idString.Str(); }
-	const char* getName() const { return m_name.Str(); }
+	const char* getIDString() const
+	{
+		return m_idString.Str();
+	}
+	const char* getName() const
+	{
+		return m_name.Str();
+	}
 
-	unsigned int getID() { return m_id; }
+	unsigned int getID()
+	{
+		return m_id;
+	}
 
-	const char* getShowLeftArrow() const { return m_showLeftArrow ? "Visible" : "Hidden"; }
-	const char* getShowRightArrow() const { return m_showRightArrow ? "Visible" : "Hidden"; }
-	const char* getShowX() const { return m_showX ? "Visible" : "Hidden"; }
+	const char* getShowLeftArrow() const
+	{
+		return m_showLeftArrow ? "Visible" : "Hidden";
+	}
+	const char* getShowRightArrow() const
+	{
+		return m_showRightArrow ? "Visible" : "Hidden";
+	}
+	const char* getShowX() const
+	{
+		return m_showX ? "Visible" : "Hidden";
+	}
 
 	RoleItem* getRole() const;
 	void setRole( RoleItem* role );
-	void nullifyRole() { m_role = nullptr; }
-	unsigned int roleID() { return m_roleID; }
+	void nullifyRole()
+	{
+		m_role = nullptr;
+	}
+	unsigned int roleID()
+	{
+		return m_roleID;
+	}
+
 private:
 	unsigned int m_id = 0;
 	Noesis::String m_idString;
 	Noesis::String m_name;
 	MilitaryProxy* m_proxy = nullptr;
 
-	bool m_showLeftArrow = true;
+	bool m_showLeftArrow  = true;
 	bool m_showRightArrow = true;
-	bool m_showX = true;
+	bool m_showX          = true;
 
 	unsigned int m_roleID = 0;
-	RoleItem* m_role = nullptr;
-	
+	RoleItem* m_role      = nullptr;
+
 	NS_DECLARE_REFLECTION( SquadGnome, NoesisApp::NotifyPropertyChangedBase )
 };
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 class SquadItem final : public NoesisApp::NotifyPropertyChangedBase
@@ -139,11 +182,20 @@ class SquadItem final : public NoesisApp::NotifyPropertyChangedBase
 public:
 	SquadItem( const GuiSquad& squad, MilitaryProxy* proxy );
 
-	const char* getIDString() const { return m_idString.Str(); }
-	const char* getName() const { return m_name.Str(); }
+	const char* getIDString() const
+	{
+		return m_idString.Str();
+	}
+	const char* getName() const
+	{
+		return m_name.Str();
+	}
 	void setName( const char* value );
 
-	unsigned int getID() { return m_id; }
+	unsigned int getID()
+	{
+		return m_id;
+	}
 
 	void updatePriorities( const QList<GuiTargetPriority>& prios );
 
@@ -158,17 +210,28 @@ private:
 	Noesis::String m_name;
 	MilitaryProxy* m_proxy = nullptr;
 
-	bool m_showLeftArrow = true;
+	bool m_showLeftArrow  = true;
 	bool m_showRightArrow = true;
 
 	bool m_showConfig = false;
 
-	const char* getShowLeftArrow() const { return m_showLeftArrow ? "Visible" : "Hidden"; }
-	const char* getShowRightArrow() const { return m_showRightArrow ? "Visible" : "Hidden"; }
-	const char* getShowX() const { return ( m_id != 0 ) ? "Visible" : "Hidden"; }
-	const char* getShowConfig() const { return m_showConfig ? "Visible" : "Collapsed"; }
+	const char* getShowLeftArrow() const
+	{
+		return m_showLeftArrow ? "Visible" : "Hidden";
+	}
+	const char* getShowRightArrow() const
+	{
+		return m_showRightArrow ? "Visible" : "Hidden";
+	}
+	const char* getShowX() const
+	{
+		return ( m_id != 0 ) ? "Visible" : "Hidden";
+	}
+	const char* getShowConfig() const
+	{
+		return m_showConfig ? "Visible" : "Collapsed";
+	}
 
-	
 	Noesis::Ptr<Noesis::ObservableCollection<SquadGnome>> m_gnomes;
 
 	void onShowConfigCmd( BaseComponent* param );
@@ -187,15 +250,20 @@ private:
 	NS_DECLARE_REFLECTION( SquadItem, NoesisApp::NotifyPropertyChangedBase )
 };
 
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 class UniformModelType final : public Noesis::BaseComponent
 {
 public:
 	UniformModelType( QString sid, QString name );
 
-	const char* getName() const { return m_name.Str(); }
-	const char* sid() const { return m_sid.Str(); }
+	const char* getName() const
+	{
+		return m_name.Str();
+	}
+	const char* sid() const
+	{
+		return m_sid.Str();
+	}
 
 private:
 	Noesis::String m_name;
@@ -210,8 +278,14 @@ class UniformModelMaterial final : public Noesis::BaseComponent
 public:
 	UniformModelMaterial( QString sid, QString name );
 
-	const char* getName() const { return m_name.Str(); }
-	const char* sid() const { return m_sid.Str(); }
+	const char* getName() const
+	{
+		return m_name.Str();
+	}
+	const char* sid() const
+	{
+		return m_sid.Str();
+	}
 
 private:
 	Noesis::String m_name;
@@ -220,15 +294,20 @@ private:
 	NS_DECLARE_REFLECTION( UniformModelMaterial, Noesis::BaseComponent )
 };
 
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 class UniformModelItem final : public NoesisApp::NotifyPropertyChangedBase
 {
 public:
 	UniformModelItem( const GuiUniformItem& gui, unsigned int roleID, MilitaryProxy* proxy );
 
-	const char* getName() const { return m_name.Str(); }
-	const char* sid() const { return m_sid.Str(); }
+	const char* getName() const
+	{
+		return m_name.Str();
+	}
+	const char* sid() const
+	{
+		return m_sid.Str();
+	}
 
 	void setPossibleMats( QStringList mats );
 
@@ -236,26 +315,37 @@ private:
 	Noesis::String m_name;
 	Noesis::String m_sid;
 	MilitaryProxy* m_proxy = nullptr;
-	unsigned int m_roleID = 0;
+	unsigned int m_roleID  = 0;
 
 	QString m_mat;
-	
-	Noesis::ObservableCollection<UniformModelType>* availableTypes() const { return m_availableTypes; }
-	Noesis::ObservableCollection<UniformModelMaterial>* availableMaterials() const { return m_availableMats; }
+
+	Noesis::ObservableCollection<UniformModelType>* availableTypes() const
+	{
+		return m_availableTypes;
+	}
+	Noesis::ObservableCollection<UniformModelMaterial>* availableMaterials() const
+	{
+		return m_availableMats;
+	}
 
 	void setSelectedType( UniformModelType* type );
-	UniformModelType* getSelectedType() const { return m_selectedType; };
+	UniformModelType* getSelectedType() const
+	{
+		return m_selectedType;
+	};
 	void setSelectedMaterial( UniformModelMaterial* mat );
-	UniformModelMaterial* getSelectedMaterial() const { return m_selectedMat; };
+	UniformModelMaterial* getSelectedMaterial() const
+	{
+		return m_selectedMat;
+	};
 
-	UniformModelType* m_selectedType = nullptr;
+	UniformModelType* m_selectedType    = nullptr;
 	UniformModelMaterial* m_selectedMat = nullptr;
 
 	Noesis::Ptr<Noesis::ObservableCollection<UniformModelType>> m_availableTypes;
 	Noesis::Ptr<Noesis::ObservableCollection<UniformModelMaterial>> m_availableMats;
 
-
-	NS_DECLARE_REFLECTION( UniformModelItem,  NoesisApp::NotifyPropertyChangedBase )
+	NS_DECLARE_REFLECTION( UniformModelItem, NoesisApp::NotifyPropertyChangedBase )
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -264,11 +354,20 @@ class RoleItem final : public NoesisApp::NotifyPropertyChangedBase
 public:
 	RoleItem( const GuiMilRole& role, MilitaryProxy* proxy );
 
-	const char* getIDString() const { return m_idString.Str(); }
-	const char* getName() const { return m_name.Str(); }
+	const char* getIDString() const
+	{
+		return m_idString.Str();
+	}
+	const char* getName() const
+	{
+		return m_name.Str();
+	}
 	void setName( const char* value );
 
-	unsigned int getID() { return m_id; }
+	unsigned int getID()
+	{
+		return m_id;
+	}
 	void updatePossibleMaterials( QString slot, QStringList mats );
 
 	bool GetCivilian() const;
@@ -280,19 +379,30 @@ private:
 	Noesis::String m_name;
 	MilitaryProxy* m_proxy = nullptr;
 
-	bool m_showLeftArrow = false;
+	bool m_showLeftArrow  = false;
 	bool m_showRightArrow = false;
 
 	bool m_showConfig = false;
 
 	bool m_civilian = false;
 
-	const char* getShowLeftArrow() const { return m_showLeftArrow ? "Visible" : "Hidden"; }
-	const char* getShowRightArrow() const { return m_showRightArrow ? "Visible" : "Hidden"; }
-	const char* getShowX() const { return ( m_id != 0 ) ? "Visible" : "Hidden"; }
-	const char* getShowConfig() const { return m_showConfig ? "Visible" : "Collapsed"; }
+	const char* getShowLeftArrow() const
+	{
+		return m_showLeftArrow ? "Visible" : "Hidden";
+	}
+	const char* getShowRightArrow() const
+	{
+		return m_showRightArrow ? "Visible" : "Hidden";
+	}
+	const char* getShowX() const
+	{
+		return ( m_id != 0 ) ? "Visible" : "Hidden";
+	}
+	const char* getShowConfig() const
+	{
+		return m_showConfig ? "Visible" : "Collapsed";
+	}
 
-	
 	void onShowConfigCmd( BaseComponent* param );
 	const NoesisApp::DelegateCommand* getShowConfigCmd() const
 	{
@@ -306,18 +416,8 @@ private:
 	}
 	Noesis::Ptr<Noesis::ObservableCollection<UniformModelItem>> m_uniformItems;
 
-
 	NS_DECLARE_REFLECTION( RoleItem, NoesisApp::NotifyPropertyChangedBase )
 };
-
-
-
-
-
-
-
-
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 class MilitaryModel final : public NoesisApp::NotifyPropertyChangedBase
@@ -351,7 +451,7 @@ private:
 		return m_squads;
 	}
 	Noesis::Ptr<Noesis::ObservableCollection<SquadItem>> m_squads;
-	
+
 	void onAddSquadCmd( BaseComponent* param );
 	const NoesisApp::DelegateCommand* getAddSquadCmd() const
 	{
@@ -401,13 +501,11 @@ private:
 	}
 	NoesisApp::DelegateCommand m_moveGnomeRightCmd;
 
-
 	Noesis::ObservableCollection<RoleItem>* getRoles() const
 	{
 		return m_roles;
 	}
 	Noesis::Ptr<Noesis::ObservableCollection<RoleItem>> m_roles;
-
 
 	void onAddRoleCmd( BaseComponent* param );
 	const NoesisApp::DelegateCommand* getAddRoleCmd() const
@@ -422,9 +520,6 @@ private:
 		return &m_removeRoleCmd;
 	}
 	NoesisApp::DelegateCommand m_removeRoleCmd;
-
-
-
 
 	NS_DECLARE_REFLECTION( MilitaryModel, NotifyPropertyChangedBase )
 };

--- a/src/gui/xaml/neighborsmodel.cpp
+++ b/src/gui/xaml/neighborsmodel.cpp
@@ -16,9 +16,9 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "neighborsmodel.h"
-#include "neighborsproxy.h"
 
 #include "../strings.h"
+#include "neighborsproxy.h"
 
 #include <NsApp/Application.h>
 #include <NsCore/Log.h>
@@ -55,16 +55,16 @@ NeighborKingdomInfo::NeighborKingdomInfo( const GuiNeighborInfo& info ) :
 
 const char* NeighborKingdomInfo::getShowDiploBtn() const
 {
-	if( m_discovered && m_diploMission )
+	if ( m_discovered && m_diploMission )
 	{
 		return "Visible";
 	}
 	return "Hidden";
 }
-	
+
 const char* NeighborKingdomInfo::getShowSpyBtn() const
 {
-	if( m_discovered && m_spyMission )
+	if ( m_discovered && m_spyMission )
 	{
 		return "Visible";
 	}
@@ -73,7 +73,7 @@ const char* NeighborKingdomInfo::getShowSpyBtn() const
 
 const char* NeighborKingdomInfo::getShowRaidBtn() const
 {
-	if( m_discovered && m_raidMission )
+	if ( m_discovered && m_raidMission )
 	{
 		return "Visible";
 	}
@@ -82,7 +82,7 @@ const char* NeighborKingdomInfo::getShowRaidBtn() const
 
 const char* NeighborKingdomInfo::getShowSabotageBtn() const
 {
-	if( m_discovered && m_sabotageMission )
+	if ( m_discovered && m_sabotageMission )
 	{
 		return "Visible";
 	}
@@ -94,170 +94,170 @@ MissionInfo::MissionInfo( const Mission& mission ) :
 	m_id( mission.id ),
 	m_idString( QString::number( mission.id ).toStdString().c_str() )
 {
-	QString qTime;	
+	QString qTime;
 
-	switch( mission.type )
+	switch ( mission.type )
 	{
-	case MissionType::EXPLORE: 
-		m_title = "Explore"; 
-		switch( mission.step )
-		{
-			case MissionStep::LEAVE_MAP:
-				m_currentAction = "Leaving the area.";
-				qTime = "I haven't left yet.";
-				break;
-			case MissionStep::TRAVEL:
-				m_currentAction = "Exploring the surrounding lands.";
-				qTime = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since I left.";
-				break;
-			case MissionStep::RETURN:
-				m_currentAction = "Returning from the mission.";
-				qTime = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since I left.";
-				break;
-			case MissionStep::RETURNED:
+		case MissionType::EXPLORE:
+			m_title = "Explore";
+			switch ( mission.step )
 			{
-				bool success = mission.result.value( "Success" ).toBool();
-				if( success )
+				case MissionStep::LEAVE_MAP:
+					m_currentAction = "Leaving the area.";
+					qTime           = "I haven't left yet.";
+					break;
+				case MissionStep::TRAVEL:
+					m_currentAction = "Exploring the surrounding lands.";
+					qTime           = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since I left.";
+					break;
+				case MissionStep::RETURN:
+					m_currentAction = "Returning from the mission.";
+					qTime           = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since I left.";
+					break;
+				case MissionStep::RETURNED:
 				{
-					m_currentAction = "I found a neighboring kingdom.";
+					bool success = mission.result.value( "Success" ).toBool();
+					if ( success )
+					{
+						m_currentAction = "I found a neighboring kingdom.";
+					}
+					else
+					{
+						m_currentAction = "I failed to find something new.";
+					}
+					qTime = "It took " + S::gi().numberWord( mission.result.value( "TotalTime" ).toInt() / 24 ) + " days.";
+					break;
 				}
-				else
-				{
-					m_currentAction = "I failed to find something new.";
-				}
-				qTime = "It took " + S::gi().numberWord( mission.result.value( "TotalTime" ).toInt() / 24 ) + " days.";
-				break;
 			}
-		}
-		break;
-	case MissionType::SPY: 
-		m_title = "Spy"; 
-		switch( mission.step )
-		{
-			case MissionStep::LEAVE_MAP:
-				m_currentAction = "Leaving the area.";
-				qTime = "I haven't left yet.";
-				break;
-			case MissionStep::TRAVEL:
-				m_currentAction = "Traveling to the kingdom.";
-				qTime = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since I left.";
-				break;
-			case MissionStep::RETURN:
-				m_currentAction = "Returning from the mission.";
-				qTime = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since I left.";
-				break;
-			case MissionStep::RETURNED:
+			break;
+		case MissionType::SPY:
+			m_title = "Spy";
+			switch ( mission.step )
 			{
-				bool success = mission.result.value( "Success" ).toBool();
-				if( success )
+				case MissionStep::LEAVE_MAP:
+					m_currentAction = "Leaving the area.";
+					qTime           = "I haven't left yet.";
+					break;
+				case MissionStep::TRAVEL:
+					m_currentAction = "Traveling to the kingdom.";
+					qTime           = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since I left.";
+					break;
+				case MissionStep::RETURN:
+					m_currentAction = "Returning from the mission.";
+					qTime           = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since I left.";
+					break;
+				case MissionStep::RETURNED:
 				{
-					m_currentAction = "Success.";
+					bool success = mission.result.value( "Success" ).toBool();
+					if ( success )
+					{
+						m_currentAction = "Success.";
+					}
+					else
+					{
+						m_currentAction = "Failure.";
+					}
+					qTime = "It took " + S::gi().numberWord( mission.result.value( "TotalTime" ).toInt() / 24 ) + " days.";
+					break;
 				}
-				else
-				{
-					m_currentAction = "Failure.";
-				}
-				qTime = "It took " + S::gi().numberWord( mission.result.value( "TotalTime" ).toInt() / 24 ) + " days.";
-				break;
 			}
-		}
-		break;
-	case MissionType::EMISSARY: 
-		m_title = "Emissary";
-		switch( mission.step )
-		{
-			case MissionStep::LEAVE_MAP:
-				m_currentAction = "Leaving the area.";
-				qTime = "I haven't left yet.";
-				break;
-			case MissionStep::TRAVEL:
-				m_currentAction = "Traveling to the kingdom.";
-				qTime = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since I left.";
-				break;
-			case MissionStep::RETURN:
-				m_currentAction = "Returning from the mission.";
-				qTime = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since I left.";
-				break;
-			case MissionStep::RETURNED:
+			break;
+		case MissionType::EMISSARY:
+			m_title = "Emissary";
+			switch ( mission.step )
 			{
-				bool success = mission.result.value( "Success" ).toBool();
-				if( success )
+				case MissionStep::LEAVE_MAP:
+					m_currentAction = "Leaving the area.";
+					qTime           = "I haven't left yet.";
+					break;
+				case MissionStep::TRAVEL:
+					m_currentAction = "Traveling to the kingdom.";
+					qTime           = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since I left.";
+					break;
+				case MissionStep::RETURN:
+					m_currentAction = "Returning from the mission.";
+					qTime           = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since I left.";
+					break;
+				case MissionStep::RETURNED:
 				{
-					m_currentAction = "Success." ;
+					bool success = mission.result.value( "Success" ).toBool();
+					if ( success )
+					{
+						m_currentAction = "Success.";
+					}
+					else
+					{
+						m_currentAction = "Failure.";
+					}
+					qTime = "It took " + S::gi().numberWord( mission.result.value( "TotalTime" ).toInt() / 24 ) + " days.";
+					break;
 				}
-				else
-				{
-					m_currentAction = "Failure.";
-				}
-				qTime = "It took " + S::gi().numberWord( mission.result.value( "TotalTime" ).toInt() / 24 ) + " days.";
-				break;
 			}
-		}
-		break;
-	case MissionType::RAID: 
-		m_title = "Raid";
-		switch( mission.step )
-		{
-			case MissionStep::LEAVE_MAP:
-				m_currentAction = "Leaving the area.";
-				qTime = "We haven't left yet.";
-				break;
-			case MissionStep::TRAVEL:
-				m_currentAction = "Traveling to the kingdom.";
-				qTime = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since we left.";
-				break;
-			case MissionStep::RETURN:
-				m_currentAction = "Returning from the mission.";
-				qTime = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since we left.";
-				break;
-			case MissionStep::RETURNED:
+			break;
+		case MissionType::RAID:
+			m_title = "Raid";
+			switch ( mission.step )
 			{
-				bool success = mission.result.value( "Success" ).toBool();
-				if( success )
+				case MissionStep::LEAVE_MAP:
+					m_currentAction = "Leaving the area.";
+					qTime           = "We haven't left yet.";
+					break;
+				case MissionStep::TRAVEL:
+					m_currentAction = "Traveling to the kingdom.";
+					qTime           = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since we left.";
+					break;
+				case MissionStep::RETURN:
+					m_currentAction = "Returning from the mission.";
+					qTime           = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since we left.";
+					break;
+				case MissionStep::RETURNED:
 				{
-					m_currentAction = "Success.";
+					bool success = mission.result.value( "Success" ).toBool();
+					if ( success )
+					{
+						m_currentAction = "Success.";
+					}
+					else
+					{
+						m_currentAction = "Failure.";
+					}
+					qTime = "It took " + S::gi().numberWord( mission.result.value( "TotalTime" ).toInt() / 24 ) + " days.";
+					break;
 				}
-				else
-				{
-					m_currentAction = "Failure.";
-				}
-				qTime = "It took " + S::gi().numberWord( mission.result.value( "TotalTime" ).toInt() / 24 ) + " days.";
-				break;
 			}
-		}
-		break;
-	case MissionType::SABOTAGE: 
-		m_title = "Sabotage"; 
-		switch( mission.step )
-		{
-			case MissionStep::LEAVE_MAP:
-				m_currentAction = "Leaving the area.";
-				qTime = "We haven't left yet.";
-				break;
-			case MissionStep::TRAVEL:
-				m_currentAction = "Traveling to the kingdom.";
-				qTime = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since we left.";
-				break;
-			case MissionStep::RETURN:
-				m_currentAction = "Returning from the mission.";
-				qTime = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since we left.";
-				break;
-			case MissionStep::RETURNED:
+			break;
+		case MissionType::SABOTAGE:
+			m_title = "Sabotage";
+			switch ( mission.step )
 			{
-				bool success = mission.result.value( "Success" ).toBool();
-				if( success )
+				case MissionStep::LEAVE_MAP:
+					m_currentAction = "Leaving the area.";
+					qTime           = "We haven't left yet.";
+					break;
+				case MissionStep::TRAVEL:
+					m_currentAction = "Traveling to the kingdom.";
+					qTime           = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since we left.";
+					break;
+				case MissionStep::RETURN:
+					m_currentAction = "Returning from the mission.";
+					qTime           = "It's been " + QString::number( qMax( 1, mission.time ) ) + " hours since we left.";
+					break;
+				case MissionStep::RETURNED:
 				{
-					m_currentAction = "Success.";
+					bool success = mission.result.value( "Success" ).toBool();
+					if ( success )
+					{
+						m_currentAction = "Success.";
+					}
+					else
+					{
+						m_currentAction = "Failure.";
+					}
+					qTime = "It took " + S::gi().numberWord( mission.result.value( "TotalTime" ).toInt() / 24 ) + " days.";
+					break;
 				}
-				else
-				{
-					m_currentAction = "Failure.";
-				}
-				qTime = "It took " + S::gi().numberWord( mission.result.value( "TotalTime" ).toInt() / 24 ) + " days.";
-				break;
 			}
-		}
-		break;
+			break;
 	}
 
 	m_time = qTime.toStdString().c_str();
@@ -269,7 +269,6 @@ AvailableGnome::AvailableGnome( unsigned int id, QString name ) :
 	m_idString( QString::number( id ).toStdString().c_str() ),
 	m_name( name.toStdString().c_str() )
 {
-	
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -287,10 +286,10 @@ NeighborsModel::NeighborsModel()
 	m_newMissionBackCmd.SetExecuteFunc( MakeDelegate( this, &NeighborsModel::onNewMissionBackCmd ) );
 	m_newMissionStartCmd.SetExecuteFunc( MakeDelegate( this, &NeighborsModel::onNewMissionStartCmd ) );
 
-	m_neighborList = *new ObservableCollection<NeighborKingdomInfo>();
-	m_missionList = *new ObservableCollection<MissionInfo>();
+	m_neighborList   = *new ObservableCollection<NeighborKingdomInfo>();
+	m_missionList    = *new ObservableCollection<MissionInfo>();
 	m_availGnomeList = *new ObservableCollection<AvailableGnome>();
-	m_actionList = *new ObservableCollection<AvailableGnome>();
+	m_actionList     = *new ObservableCollection<AvailableGnome>();
 }
 
 const char* NeighborsModel::GetShowFirst() const
@@ -301,7 +300,7 @@ const char* NeighborsModel::GetShowFirst() const
 	}
 	return "Hidden";
 }
-	
+
 const char* NeighborsModel::GetShowSecond() const
 {
 	if ( m_page == NeighborsPage::Second )
@@ -322,11 +321,11 @@ const char* NeighborsModel::GetShowThird() const
 
 void NeighborsModel::onPageCmd( BaseComponent* param )
 {
-	if( param->ToString() == "First" )
+	if ( param->ToString() == "First" )
 	{
 		m_page = NeighborsPage::First;
 	}
-	else if( param->ToString() == "Second" )
+	else if ( param->ToString() == "Second" )
 	{
 		m_page = NeighborsPage::Second;
 	}
@@ -334,7 +333,7 @@ void NeighborsModel::onPageCmd( BaseComponent* param )
 	{
 		m_page = NeighborsPage::Third;
 	}
-	
+
 	OnPropertyChanged( "ShowFirst" );
 	OnPropertyChanged( "ShowSecond" );
 	OnPropertyChanged( "ShowThird" );
@@ -345,19 +344,18 @@ void NeighborsModel::onDiploMissionCmd( BaseComponent* param )
 	m_missionTitle = "New diplomatic mission to";
 	OnPropertyChanged( "MissionTitle" );
 
-	for( int i = 0; i < m_neighborList->Count(); ++i )
+	for ( int i = 0; i < m_neighborList->Count(); ++i )
 	{
 		auto neighbor = m_neighborList->Get( i );
-		auto ids = neighbor->getIDString();
+		auto ids      = neighbor->getIDString();
 
-		if( strcmp( param->ToString().Str(), ids ) == 0 )
+		if ( strcmp( param->ToString().Str(), ids ) == 0 )
 		{
-			m_missionTarget = neighbor->getName();
+			m_missionTarget   = neighbor->getName();
 			m_missionTargetID = neighbor->getID();
 			OnPropertyChanged( "MissionTarget" );
 			break;
 		}
-
 	}
 
 	m_actionList->Clear();
@@ -370,13 +368,11 @@ void NeighborsModel::onDiploMissionCmd( BaseComponent* param )
 	OnPropertyChanged( "MissionActions" );
 
 	setSelectedAction( m_actionList->Get( 0 ) );
-	
+
 	m_showSelector = true;
 	OnPropertyChanged( "ShowGnomeSelect" );
 
-
 	m_proxy->requestAvailableGnomes();
-
 
 	qDebug() << "Diplo" << param->ToString().Str();
 }
@@ -400,7 +396,7 @@ void NeighborsModel::neighborsUpdate( const QList<GuiNeighborInfo>& infos )
 {
 	m_neighborList->Clear();
 
-	for( const auto& info : infos )
+	for ( const auto& info : infos )
 	{
 		m_neighborList->Add( MakePtr<NeighborKingdomInfo>( info ) );
 	}
@@ -412,7 +408,7 @@ void NeighborsModel::missionsUpdate( const QList<Mission>& missions )
 {
 	m_missionList->Clear();
 
-	for( const auto& info : missions )
+	for ( const auto& info : missions )
 	{
 		m_missionList->Add( MakePtr<MissionInfo>( info ) );
 	}
@@ -427,13 +423,13 @@ const char* NeighborsModel::getShowGnomeSelect() const
 
 void NeighborsModel::setSelectedGnome( AvailableGnome* gnome )
 {
-	if( m_selectedGnome != gnome )
+	if ( m_selectedGnome != gnome )
 	{
 		m_selectedGnome = gnome;
 		OnPropertyChanged( "SelectedGnome" );
 	}
 }
-	
+
 AvailableGnome* NeighborsModel::getSelectedGnome() const
 {
 	return m_selectedGnome;
@@ -441,13 +437,13 @@ AvailableGnome* NeighborsModel::getSelectedGnome() const
 
 void NeighborsModel::setSelectedAction( AvailableGnome* action )
 {
-	if( m_selectedAction != action )
+	if ( m_selectedAction != action )
 	{
 		m_selectedAction = action;
 		OnPropertyChanged( "SelectedAction" );
 	}
 }
-	
+
 AvailableGnome* NeighborsModel::getSelectedAction() const
 {
 	return m_selectedAction;
@@ -463,17 +459,16 @@ const char* NeighborsModel::getMissionTitle() const
 	return m_missionTitle.Str();
 }
 
-
 void NeighborsModel::updateAvailableGnomes( const QList<GuiAvailableGnome>& gnomes )
 {
 	m_availGnomeList->Clear();
-	for( const auto& gnome : gnomes )
+	for ( const auto& gnome : gnomes )
 	{
 		m_availGnomeList->Add( MakePtr<AvailableGnome>( gnome.id, gnome.name ) );
 	}
 	OnPropertyChanged( "MissionGnomes" );
 
-	if( m_availGnomeList->Count() > 0 )
+	if ( m_availGnomeList->Count() > 0 )
 	{
 		setSelectedGnome( m_availGnomeList->Get( 0 ) );
 	}
@@ -483,28 +478,28 @@ void NeighborsModel::onNewMissionBackCmd( BaseComponent* param )
 {
 	m_showSelector = false;
 	OnPropertyChanged( "ShowGnomeSelect" );
-	m_selectedGnome = nullptr;
-	m_selectedAction = nullptr;
+	m_selectedGnome   = nullptr;
+	m_selectedAction  = nullptr;
 	m_missionTargetID = 0;
 }
 
 void NeighborsModel::onNewMissionStartCmd( BaseComponent* param )
 {
-	if( m_selectedGnome && m_selectedAction && m_missionTargetID )
+	if ( m_selectedGnome && m_selectedAction && m_missionTargetID )
 	{
 		m_showSelector = false;
 		OnPropertyChanged( "ShowGnomeSelect" );
-		
+
 		m_proxy->startMission( MissionType::EMISSARY, (MissionAction)m_selectedAction->getID(), m_missionTargetID, m_selectedGnome->getID() );
 	}
 }
 
 void NeighborsModel::updateMission( const Mission& mission )
 {
-	for( int i = 0; i < m_missionList->Count(); ++i )
+	for ( int i = 0; i < m_missionList->Count(); ++i )
 	{
 		auto mis = m_missionList->Get( i );
-		if( mis->getID() == mission.id )
+		if ( mis->getID() == mission.id )
 		{
 			m_missionList->RemoveAt( i );
 			m_missionList->Insert( i, MakePtr<MissionInfo>( mission ) );
@@ -513,7 +508,6 @@ void NeighborsModel::updateMission( const Mission& mission )
 		}
 	}
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 NS_BEGIN_COLD_REGION

--- a/src/gui/xaml/workshopmodel.cpp
+++ b/src/gui/xaml/workshopmodel.cpp
@@ -314,7 +314,6 @@ void WsCraftJob::onButtonCmd( BaseComponent* param )
 
 #pragma region TradeItems
 
-
 WsTradeItem::WsTradeItem( QString name, QString itemSID, QString materialSID, unsigned char quality, int count ) :
 	m_name( name.toStdString().c_str() ),
 	m_itemSID( itemSID ),
@@ -337,13 +336,12 @@ const char* WsTradeItem::GetCount() const
 
 void WsTradeItem::SetCount( int count )
 {
-	m_count = count;
+	m_count       = count;
 	m_countString = QString::number( count ).toStdString().c_str();
 	OnPropertyChanged( "Count" );
 }
 
 #pragma endregion TradeItems
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 WorkshopModel::WorkshopModel()
@@ -444,8 +442,6 @@ void WorkshopModel::onUpdateCraftList( const GuiWorkshopInfo& info )
 	}
 }
 
-
-
 bool WorkshopModel::GetSuspended() const
 {
 	return m_suspended;
@@ -453,7 +449,7 @@ bool WorkshopModel::GetSuspended() const
 
 void WorkshopModel::SetSuspended( bool value )
 {
-	if( m_suspended != value )
+	if ( m_suspended != value )
 	{
 		m_suspended = value;
 		m_proxy->setBasicOptions( m_workshopID, m_name.Str(), m_prios->IndexOf( m_selectedPrio ), m_suspended, m_acceptGenerated, m_autoCraftMissing, m_connectStockpile );
@@ -566,7 +562,6 @@ void WorkshopModel::SetName( const char* value )
 	OnPropertyChanged( "Name" );
 }
 
-
 #pragma region ButcherSpecific
 
 bool WorkshopModel::GetButcherExcess() const
@@ -605,9 +600,9 @@ void WorkshopModel::updateTraderStock( const QList<GuiTradeItem>& items )
 {
 	m_traderStock->Clear();
 
-	for( const auto& item : items )
+	for ( const auto& item : items )
 	{
-		if( item.count - item.reserved > 0 )
+		if ( item.count - item.reserved > 0 )
 		{
 			m_traderStock->Add( MakePtr<WsTradeItem>( item.name, item.itemSID, item.materialSIDorGender, item.quality, item.count - item.reserved ) );
 		}
@@ -616,22 +611,21 @@ void WorkshopModel::updateTraderStock( const QList<GuiTradeItem>& items )
 
 	m_traderOffer->Clear();
 
-	for( const auto& item : items )
+	for ( const auto& item : items )
 	{
-		if( item.reserved > 0 )
+		if ( item.reserved > 0 )
 		{
 			m_traderOffer->Add( MakePtr<WsTradeItem>( item.name, item.itemSID, item.materialSIDorGender, item.quality, item.reserved ) );
 		}
 	}
 	OnPropertyChanged( "TraderOffer" );
 }
-	
 
 void WorkshopModel::updatePlayerStock( const QList<GuiTradeItem>& items )
 {
 	m_playerStock->Clear();
 
-	for( const auto& item : items )
+	for ( const auto& item : items )
 	{
 		m_playerStock->Add( MakePtr<WsTradeItem>( item.name, item.itemSID, item.materialSIDorGender, item.quality, item.count ) );
 	}
@@ -639,25 +633,24 @@ void WorkshopModel::updatePlayerStock( const QList<GuiTradeItem>& items )
 
 	m_playerOffer->Clear();
 
-	for( const auto& item : items )
+	for ( const auto& item : items )
 	{
-		if( item.reserved > 0 )
+		if ( item.reserved > 0 )
 		{
 			m_playerOffer->Add( MakePtr<WsTradeItem>( item.name, item.itemSID, item.materialSIDorGender, item.quality, item.reserved ) );
 		}
 	}
 	OnPropertyChanged( "PlayerOffer" );
-
 }
 
 void WorkshopModel::updateTraderStockItem( const GuiTradeItem& gti )
 {
-	for( int i = 0; i < m_traderStock->Count(); ++i )
+	for ( int i = 0; i < m_traderStock->Count(); ++i )
 	{
 		auto item = m_traderStock->Get( i );
-		if( item->m_itemSID == gti.itemSID && item->m_materialSID == gti.materialSIDorGender && item->m_quality == gti.quality )
+		if ( item->m_itemSID == gti.itemSID && item->m_materialSID == gti.materialSIDorGender && item->m_quality == gti.quality )
 		{
-			if( gti.count - gti.reserved > 0 )
+			if ( gti.count - gti.reserved > 0 )
 			{
 				item->SetCount( gti.count - gti.reserved );
 				break;
@@ -671,14 +664,14 @@ void WorkshopModel::updateTraderStockItem( const GuiTradeItem& gti )
 		}
 	}
 	bool found = false;
-	for( int i = 0; i < m_traderOffer->Count(); ++i )
+	for ( int i = 0; i < m_traderOffer->Count(); ++i )
 	{
 		auto item = m_traderOffer->Get( i );
-		
-		if( item->m_itemSID == gti.itemSID && item->m_materialSID == gti.materialSIDorGender && item->m_quality == gti.quality )
+
+		if ( item->m_itemSID == gti.itemSID && item->m_materialSID == gti.materialSIDorGender && item->m_quality == gti.quality )
 		{
 			found = true;
-			if( gti.reserved > 0 )
+			if ( gti.reserved > 0 )
 			{
 				item->SetCount( gti.reserved );
 				break;
@@ -691,7 +684,7 @@ void WorkshopModel::updateTraderStockItem( const GuiTradeItem& gti )
 			}
 		}
 	}
-	if( !found )
+	if ( !found )
 	{
 		m_traderOffer->Add( MakePtr<WsTradeItem>( gti.name, gti.itemSID, gti.materialSIDorGender, gti.quality, gti.reserved ) );
 		OnPropertyChanged( "TraderOffer" );
@@ -700,12 +693,12 @@ void WorkshopModel::updateTraderStockItem( const GuiTradeItem& gti )
 
 void WorkshopModel::updatePlayerStockItem( const GuiTradeItem& gti )
 {
-	for( int i = 0; i < m_playerStock->Count(); ++i )
+	for ( int i = 0; i < m_playerStock->Count(); ++i )
 	{
 		auto item = m_playerStock->Get( i );
-		if( item->m_itemSID == gti.itemSID && item->m_materialSID == gti.materialSIDorGender && item->m_quality == gti.quality )
+		if ( item->m_itemSID == gti.itemSID && item->m_materialSID == gti.materialSIDorGender && item->m_quality == gti.quality )
 		{
-			if( gti.count - gti.reserved > 0 )
+			if ( gti.count - gti.reserved > 0 )
 			{
 				item->SetCount( gti.count - gti.reserved );
 				break;
@@ -719,14 +712,14 @@ void WorkshopModel::updatePlayerStockItem( const GuiTradeItem& gti )
 		}
 	}
 	bool found = false;
-	for( int i = 0; i < m_playerOffer->Count(); ++i )
+	for ( int i = 0; i < m_playerOffer->Count(); ++i )
 	{
 		auto item = m_playerOffer->Get( i );
-		
-		if( item->m_itemSID == gti.itemSID && item->m_materialSID == gti.materialSIDorGender && item->m_quality == gti.quality )
+
+		if ( item->m_itemSID == gti.itemSID && item->m_materialSID == gti.materialSIDorGender && item->m_quality == gti.quality )
 		{
 			found = true;
-			if( gti.reserved > 0 )
+			if ( gti.reserved > 0 )
 			{
 				item->SetCount( gti.reserved );
 				break;
@@ -739,7 +732,7 @@ void WorkshopModel::updatePlayerStockItem( const GuiTradeItem& gti )
 			}
 		}
 	}
-	if( !found )
+	if ( !found )
 	{
 		m_playerOffer->Add( MakePtr<WsTradeItem>( gti.name, gti.itemSID, gti.materialSIDorGender, gti.quality, gti.reserved ) );
 		OnPropertyChanged( "PlayerOffer" );
@@ -748,13 +741,13 @@ void WorkshopModel::updatePlayerStockItem( const GuiTradeItem& gti )
 
 void WorkshopModel::SetSelectedTraderStock( WsTradeItem* item )
 {
-	if( m_selectedTraderStock != item )
+	if ( m_selectedTraderStock != item )
 	{
 		m_selectedTraderStock = item;
 		OnPropertyChanged( "SelectedTraderStock" );
 	}
 }
-	
+
 WsTradeItem* WorkshopModel::GetSelectedTraderStock() const
 {
 	return m_selectedTraderStock;
@@ -762,13 +755,13 @@ WsTradeItem* WorkshopModel::GetSelectedTraderStock() const
 
 void WorkshopModel::SetSelectedTraderOffer( WsTradeItem* item )
 {
-	if( m_selectedTraderOffer != item )
+	if ( m_selectedTraderOffer != item )
 	{
 		m_selectedTraderOffer = item;
 		OnPropertyChanged( "SelectedTraderOffer" );
 	}
 }
-	
+
 WsTradeItem* WorkshopModel::GetSelectedTraderOffer() const
 {
 	return m_selectedTraderOffer;
@@ -776,13 +769,13 @@ WsTradeItem* WorkshopModel::GetSelectedTraderOffer() const
 
 void WorkshopModel::SetSelectedPlayerStock( WsTradeItem* item )
 {
-	if( m_selectedPlayerStock != item )
+	if ( m_selectedPlayerStock != item )
 	{
 		m_selectedPlayerStock = item;
 		OnPropertyChanged( "SelectedPlayerStock" );
 	}
 }
-	
+
 WsTradeItem* WorkshopModel::GetSelectedPlayerStock() const
 {
 	return m_selectedPlayerStock;
@@ -790,13 +783,13 @@ WsTradeItem* WorkshopModel::GetSelectedPlayerStock() const
 
 void WorkshopModel::SetSelectedPlayerOffer( WsTradeItem* item )
 {
-	if( m_selectedPlayerOffer != item )
+	if ( m_selectedPlayerOffer != item )
 	{
 		m_selectedPlayerOffer = item;
 		OnPropertyChanged( "SelectedPlayerOffer" );
 	}
 }
-	
+
 WsTradeItem* WorkshopModel::GetSelectedPlayerOffer() const
 {
 	return m_selectedPlayerOffer;
@@ -805,15 +798,15 @@ WsTradeItem* WorkshopModel::GetSelectedPlayerOffer() const
 void WorkshopModel::onAmountCmd( BaseComponent* param )
 {
 	QString qParam = param->ToString().Str();
-	if( qParam == "1" )
+	if ( qParam == "1" )
 	{
 		m_amountToTransfer = CheckedAmount::Amount1;
 	}
-	else if( qParam == "10" )
+	else if ( qParam == "10" )
 	{
 		m_amountToTransfer = CheckedAmount::Amount10;
 	}
-	else if( qParam == "100" )
+	else if ( qParam == "100" )
 	{
 		m_amountToTransfer = CheckedAmount::Amount100;
 	}
@@ -829,7 +822,7 @@ void WorkshopModel::onAmountCmd( BaseComponent* param )
 
 bool WorkshopModel::GetAmount1Checked() const
 {
-	if( m_amountToTransfer == CheckedAmount::Amount1 )
+	if ( m_amountToTransfer == CheckedAmount::Amount1 )
 	{
 		return true;
 	}
@@ -838,7 +831,7 @@ bool WorkshopModel::GetAmount1Checked() const
 
 bool WorkshopModel::GetAmount10Checked() const
 {
-	if( m_amountToTransfer == CheckedAmount::Amount10 )
+	if ( m_amountToTransfer == CheckedAmount::Amount10 )
 	{
 		return true;
 	}
@@ -847,7 +840,7 @@ bool WorkshopModel::GetAmount10Checked() const
 
 bool WorkshopModel::GetAmount100Checked() const
 {
-	if( m_amountToTransfer == CheckedAmount::Amount100 )
+	if ( m_amountToTransfer == CheckedAmount::Amount100 )
 	{
 		return true;
 	}
@@ -856,7 +849,7 @@ bool WorkshopModel::GetAmount100Checked() const
 
 bool WorkshopModel::GetAmountAllChecked() const
 {
-	if( m_amountToTransfer == CheckedAmount::AmountAll )
+	if ( m_amountToTransfer == CheckedAmount::AmountAll )
 	{
 		return true;
 	}
@@ -866,8 +859,8 @@ bool WorkshopModel::GetAmountAllChecked() const
 void WorkshopModel::onTransferCmd( BaseComponent* param )
 {
 	QString qParam = param->ToString().Str();
-	int amount = 0;
-	switch( m_amountToTransfer )
+	int amount     = 0;
+	switch ( m_amountToTransfer )
 	{
 		case CheckedAmount::Amount1:
 			amount = 1;
@@ -883,30 +876,30 @@ void WorkshopModel::onTransferCmd( BaseComponent* param )
 			break;
 	}
 
-	if( qParam == "TraderLeft" )
+	if ( qParam == "TraderLeft" )
 	{
-		if( m_selectedTraderOffer )
+		if ( m_selectedTraderOffer )
 		{
 			m_proxy->traderOffertoStock( m_workshopID, m_selectedTraderOffer->m_itemSID, m_selectedTraderOffer->m_materialSID, m_selectedTraderOffer->m_quality, amount );
 		}
 	}
-	else if( qParam == "TraderRight" )
+	else if ( qParam == "TraderRight" )
 	{
-		if( m_selectedTraderStock )
+		if ( m_selectedTraderStock )
 		{
 			m_proxy->traderStocktoOffer( m_workshopID, m_selectedTraderStock->m_itemSID, m_selectedTraderStock->m_materialSID, m_selectedTraderStock->m_quality, amount );
 		}
 	}
-	else if( qParam == "PlayerLeft" )
+	else if ( qParam == "PlayerLeft" )
 	{
-		if( m_selectedPlayerOffer )
+		if ( m_selectedPlayerOffer )
 		{
 			m_proxy->playerOffertoStock( m_workshopID, m_selectedPlayerOffer->m_itemSID, m_selectedPlayerOffer->m_materialSID, m_selectedPlayerOffer->m_quality, amount );
 		}
 	}
-	else if( qParam == "PlayerRight" )
+	else if ( qParam == "PlayerRight" )
 	{
-		if( m_selectedPlayerStock )
+		if ( m_selectedPlayerStock )
 		{
 			m_proxy->playerStocktoOffer( m_workshopID, m_selectedPlayerStock->m_itemSID, m_selectedPlayerStock->m_materialSID, m_selectedPlayerStock->m_quality, amount );
 		}
@@ -917,7 +910,7 @@ const char* WorkshopModel::GetTraderValue() const
 {
 	return m_traderValue.Str();
 }
-	
+
 const char* WorkshopModel::GetPlayerValue() const
 {
 	return m_playerValue.Str();
@@ -928,7 +921,7 @@ void WorkshopModel::updateTraderValue( int value )
 	m_traderValue = QString::number( value ).toStdString().c_str();
 	OnPropertyChanged( "TraderValue" );
 }
-	
+
 void WorkshopModel::updatePlayerValue( int value )
 {
 	m_playerValue = QString::number( value ).toStdString().c_str();

--- a/src/gui/xaml/workshopmodel.h
+++ b/src/gui/xaml/workshopmodel.h
@@ -187,10 +187,10 @@ private:
 
 #pragma endregion CraftingListTab
 
-
 #pragma region TradeItems
 
-enum class CheckedAmount : unsigned char {
+enum class CheckedAmount : unsigned char
+{
 	Amount1,
 	Amount10,
 	Amount100,
@@ -212,25 +212,16 @@ public:
 	QString m_materialSID;
 
 	unsigned char m_quality = 0;
-	int m_count = 0;
-
+	int m_count             = 0;
 
 private:
 	Noesis::String m_name;
 	Noesis::String m_countString;
 
-	
-
-
 	NS_DECLARE_REFLECTION( WsTradeItem, NoesisApp::NotifyPropertyChangedBase )
 };
 
 #pragma endregion TradeItems
-
-
-
-
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 class WorkshopModel final : public NoesisApp::NotifyPropertyChangedBase
@@ -243,7 +234,7 @@ public:
 
 	void updateTraderStock( const QList<GuiTradeItem>& items );
 	void updatePlayerStock( const QList<GuiTradeItem>& items );
-	
+
 	void updateTraderStockItem( const GuiTradeItem& item );
 	void updatePlayerStockItem( const GuiTradeItem& item );
 
@@ -291,7 +282,6 @@ private:
 	}
 	Noesis::Ptr<Noesis::ObservableCollection<WsCraftJob>> m_jobs;
 
-
 #pragma region TradeItemLists
 	Noesis::ObservableCollection<WsTradeItem>* GetTraderStock() const
 	{
@@ -301,7 +291,6 @@ private:
 	WsTradeItem* m_selectedTraderStock = nullptr;
 	void SetSelectedTraderStock( WsTradeItem* item );
 	WsTradeItem* GetSelectedTraderStock() const;
-
 
 	Noesis::ObservableCollection<WsTradeItem>* GetTraderOffer() const
 	{
@@ -339,7 +328,7 @@ private:
 	}
 	NoesisApp::DelegateCommand m_amountCmd;
 
-	bool GetAmount1Checked() const ;
+	bool GetAmount1Checked() const;
 	bool GetAmount10Checked() const;
 	bool GetAmount100Checked() const;
 	bool GetAmountAllChecked() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,8 +65,8 @@ QPointer<QFile> openLog()
 		fileName = folder + fileName;
 	}
 
-	QPointer<QFile> outFile(new QFile( fileName ));
-	if(outFile->open( QIODevice::WriteOnly | QIODevice::Append ))
+	QPointer<QFile> outFile( new QFile( fileName ) );
+	if ( outFile->open( QIODevice::WriteOnly | QIODevice::Append ) )
 	{
 		return outFile;
 	}
@@ -81,11 +81,11 @@ void logOutput( QtMsgType type, const QMessageLogContext& context, const QString
 	if ( message.startsWith( "libpng warning:" ) )
 		return;
 
-	QString filedate  = QDateTime::currentDateTime().toString( "yyyy.MM.dd hh:mm:ss:zzz" );
+	QString filedate = QDateTime::currentDateTime().toString( "yyyy.MM.dd hh:mm:ss:zzz" );
 #ifdef _WIN32
 	if ( IsDebuggerPresent() )
 #else
-	if (verbose)
+	if ( verbose )
 #endif // _WIN32
 	{
 		QString debugdate = QDateTime::currentDateTime().toString( "hh:mm:ss:zzz" );
@@ -194,7 +194,7 @@ int main( int argc, char* argv[] )
 
 	//MainWindow w;
 	MainWindow w;
-	
+
 #ifdef _WIN32
 	w.setIcon( QFileIconProvider().icon( QFileInfo( QCoreApplication::applicationFilePath() ) ) );
 #endif // _WIN32
@@ -202,7 +202,7 @@ int main( int argc, char* argv[] )
 	w.resize( width, height );
 	w.setPosition( Config::getInstance().get( "WindowPosX" ).toInt(), Config::getInstance().get( "WindowPosY" ).toInt() );
 	w.show();
-	if( Config::getInstance().get( "fullscreen" ).toBool() )
+	if ( Config::getInstance().get( "fullscreen" ).toBool() )
 	{
 		w.onFullScreen( true );
 	}
@@ -223,4 +223,3 @@ extern "C"
 	__declspec( dllexport ) DWORD AmdPowerXpressRequestHighPerformance = 1;
 }
 #endif // _WIN32
-


### PR DESCRIPTION
The first commit (41d7f02) is an automated code formatting, following the .clang-format file, in preparation for the removal of some of the warning messages that are plaguing the GCC compiling on Linux.

The second (57ce3bc) is fixing some of the -Wsign-compare warnings. There are some left, that need some analysis to check if the ints or the unsigned ints must be cast.