### PR TITLE
Fix scaled down rendering area on HiDPI screens

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -715,7 +715,9 @@ void MainWindow::resizeGL( int w, int h )
 	{
 		m_view->SetSize( this->width(), this->height() );
 	}
-	m_renderer->resize( this->width(), this->height() );
+
+	const qreal scaling = this->devicePixelRatio();
+	m_renderer->resize( this->width() * scaling, this->height() * scaling );
 
 	emit signalWindowSize( this->width(), this->height() );
 


### PR DESCRIPTION
Takes screen scaling factor into account when resizing the renderer. Tested OK on my x2 hidpi setup on arch, seems to be working with hidpi off (running the app with `QT_QPA_PLAFORM=xcb` on my wayland setup).

Closes #120