### PR TITLE
Auto-generated documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,51 @@
+name: Docs
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - uses: dschep/install-pipenv-action@v1
+      - uses: actions/checkout@v2
+
+      - name: Download Tilesheets
+        uses: carlosperate/download-file-action@v1.0.3
+        id: download-tilesheet
+        with:
+          file-url: 'https://github.com/rschurade/IngnomiaBuildDeps/raw/master/tilesheet.zip'
+
+      - name: Unpack Tilesheets
+        uses: DuckSoft/extract-7z-action@v1.0
+        with:
+          pathSource: ${{ steps.download-tilesheet.outputs.file-path }}
+          pathTarget: content
+
+      - name: Setup venv
+        working-directory: docs
+        run: |
+          pipenv install
+
+      - name: Generate docs
+        working-directory: docs
+        run: |
+          pipenv run ./generate.py --build ${GITHUB_REF#refs/*/}
+
+      - name: Deploy docs to gh-pages
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          keep_history: true
+          build_dir: docs/html
+          fqdn: ${{ secrets.DOCS_DOMAIN }}
+          jekyll: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,6 @@ jobs:
           pipenv run ./generate.py --build ${GITHUB_REF#refs/*/}
 
       - name: Deploy docs to gh-pages
-        if: success()
         uses: crazy-max/ghaction-github-pages@v2
         with:
           keep_history: true

--- a/.gitignore
+++ b/.gitignore
@@ -377,3 +377,7 @@ build/
 
 # Visual studio code
 .vscode
+
+# Doc
+/docs/html
+

--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ If no errors have occured, proceed by building the project with the chosen build
 cmake --build "<BUILD_DIR>"
 ```
 
+### Building the documentation ###
+
+Documentation building scripts are in the `docs/` directory. To rebuild documentation you will need:
+
+* Python 3.9
+* Pipenv
+* Tilesheets from an existing installation (in the `content/tilesheet` directory, as when building the game)
+
+From the `docs/` directory, run:
+
+```bash
+pipenv install
+pipenv run ./generate.py
+```
+
+Output is generated in `docs/html`. You can specify a different output by passing `--output path/to/dir` to the generation script.
+
+Generation will fail when the output directory exists. Use the `--overwrite` option in that case, but be warned that it will wipe the output directory completely.
+
 ### Forks on Github ###
 
 When forking the project on Github, you should add `NOESIS_LICENSE_KEY` and `NOESIS_LICENSE_NAME` as secrets in your repositories configuration under Settings/Secrets. If not provided, CI builds will fail for your fork.

--- a/docs/Pipfile
+++ b/docs/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+jinja2 = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/docs/Pipfile.lock
+++ b/docs/Pipfile.lock
@@ -1,0 +1,68 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "89a5336035e8244fc3f6442bfd9c654067e256d1d16c12d0548bf2589871414a"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "jinja2": {
+            "hashes": [
+                "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
+                "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
+            ],
+            "index": "pypi",
+            "version": "==2.11.2"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.1.1"
+        }
+    },
+    "develop": {}
+}

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+
+from lib.util import DOCDIR
+from lib.render import render
+from lib.store import Store
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", "--theme", help="theme name, defaults to 'default'", default="default")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="output directory, defaults to 'docs/html' in the repository",
+        default=os.path.join(DOCDIR, "html"),
+    )
+    parser.add_argument(
+        "-f", "--overwrite", help="allow overwriting output directory when it exists", action="store_true"
+    )
+    parser.add_argument("-b", "--build", help="set build ID information", default=None)
+
+    ns = parser.parse_args()
+
+    if os.path.exists(ns.output) and not ns.overwrite:
+        print(f"Error: output path {ns.output} exists, pass --overwrite to overwrite")
+        sys.exit(1)
+
+    render(Store(), ns.theme, ns.output, ns.build)

--- a/docs/lib/db.py
+++ b/docs/lib/db.py
@@ -240,7 +240,9 @@ class Database:
         return self.conn.execute("SELECT basesprite, sprite FROM Sprites_Random WHERE id = ?", (id,))
 
     def sprite_rotations(self, id):
-        return self.conn.execute("SELECT basesprite, sprite, rotation FROM Sprites_Rotations WHERE id = ?", (id,))
+        return self.conn.execute(
+            "SELECT basesprite, sprite, rotation, effect FROM Sprites_Rotations WHERE id = ?", (id,)
+        )
 
     def sprite_seasons(self, id):
         return self.conn.execute("SELECT basesprite, season FROM Sprites_Seasons WHERE id = ?", (id,))

--- a/docs/lib/db.py
+++ b/docs/lib/db.py
@@ -1,0 +1,314 @@
+import os
+import sqlite3
+
+from .util import DOCDIR, empty, log
+
+DB_PATH = os.path.join(DOCDIR, "..", "content", "db", "ingnomia.db.sql")
+
+
+class Database:
+    def __init__(self):
+        self.conn = sqlite3.connect(":memory:", uri=True)
+        with open(DB_PATH) as f:
+            log("Loading database")
+            self.conn.executescript(f.read())
+
+    def basesprite(self, id):
+        for row in self.conn.execute("SELECT sourcerectangle, tilesheet FROM BaseSprites WHERE id = ?", (id,)):
+            return row
+        return None
+
+    def basesprites(self):
+        return [id for (id,) in self.conn.execute("SELECT id FROM BaseSprites")]
+
+    def categories(self):
+        return [cat for (cat,) in self.conn.execute("SELECT DISTINCT category FROM Items")]
+
+    def construction(self, id):
+        for row in self.conn.execute("SELECT category, type FROM Constructions WHERE id = ?", (id,)):
+            return row
+        return None
+
+    def construction_components(self, id):
+        return self.conn.execute(
+            "SELECT itemid, amount, materials, materialtypes FROM Constructions_Components WHERE id = ?", (id,)
+        )
+
+    def construction_sprites(self, id):
+        return self.conn.execute(
+            "SELECT COALESCE(spriteidoverride, spriteid), offset FROM Constructions_Sprites WHERE id = ? ORDER BY offset",
+            (id,),
+        )
+
+    def constructions(self):
+        return [id for (id,) in self.conn.execute("SELECT id FROM Constructions")]
+
+    def constructions_for_item(self, item):
+        return [
+            id for (id,) in self.conn.execute("SELECT id FROM Constructions WHERE type = 'Item' AND id = ?", (item,))
+        ]
+
+    def constructions_using_item(self, item):
+        return [id for (id,) in self.conn.execute("SELECT id FROM Constructions_Components WHERE itemid = ?", (item,))]
+
+    def container(self, id):
+        for row in self.conn.execute("SELECT capacity, requiresame FROM Containers WHERE id = ?", (id,)):
+            return row
+        return None
+
+    def container_items(self, id):
+        return self.conn.execute(
+            """SELECT id, spriteid, category, itemgroup
+               FROM Items
+               WHERE '|' || allowedcontainers || '|' LIKE '%|' || ? || '|%'
+                  OR '|' || carrycontainer || '|' LIKE '%|' || ? || '|%'""",
+            (id, id),
+        )
+
+    def craft(self, craft):
+        for row in self.conn.execute(
+            """SELECT id, itemid, amount, productiontime, skillid, resultmaterial, resultmaterialtypes, conversionmaterial
+               FROM Crafts c
+               WHERE id = ?
+                 AND (amount = 0 OR EXISTS (SELECT 1 FROM Items i WHERE i.id = c.itemid))""",
+            (craft,),
+        ):
+            return row
+        return None
+
+    def craft_components(self, craft):
+        return self.conn.execute(
+            "SELECT amount, itemid, allowedmaterial, allowedmaterialtype FROM Crafts_Components WHERE id = ?",
+            (craft,),
+        )
+
+    def crafts_using_item(self, item):
+        return [
+            id for (id,) in self.conn.execute("SELECT DISTINCT id FROM Crafts_Components WHERE itemid = ?", (item,))
+        ]
+
+    def drink_items(self):
+        return self.conn.execute(
+            """SELECT id, spriteid, category, itemgroup, drinkvalue
+               FROM Items
+               WHERE drinkvalue > 0"""
+        )
+
+    def food_items(self):
+        return self.conn.execute(
+            """SELECT id, spriteid, category, itemgroup, eatvalue
+               FROM Items
+               WHERE eatvalue > 0"""
+        )
+
+    def group_items(self, cat, group):
+        return self.conn.execute(
+            "SELECT id, spriteid, allowedmaterials, allowedmaterialtypes FROM Items WHERE category = ? AND itemgroup = ?",
+            (cat, group),
+        )
+
+    def item_crafts(self, item):
+        return self.conn.execute(
+            "SELECT id, amount, productiontime, skillid, resultmaterial, resultmaterialtypes, conversionmaterial FROM Crafts WHERE itemid = ?",
+            (item,),
+        )
+
+    def item_groups(self, cat):
+        return [
+            group
+            for (group,) in self.conn.execute(
+                "SELECT DISTINCT itemgroup FROM Items WHERE category = ?",
+                (cat,),
+            )
+        ]
+
+    def item_materials(self, item):
+        for (mat, mattypes) in self.conn.execute(
+            "SELECT allowedmaterials, allowedmaterialtypes FROM Items WHERE id = ?", (item,)
+        ):
+            return (mat, mattypes)
+        return (None, None)
+
+    def item_sprite(self, item):
+        for (sprite,) in self.conn.execute("SELECT spriteid FROM Items WHERE id = ?", (item,)):
+            return sprite
+        return None
+
+    def items(self):
+        return self.conn.execute(
+            """SELECT id, category, itemgroup, stacksize, value, eatvalue, drinkvalue, lightintensity,
+                      allowedmaterials, allowedmaterialtypes, allowedcontainers, carrycontainer, spriteid
+               FROM Items"""
+        )
+
+    def items_craftable_with(self, items, workshops):
+        values = [*workshops, *items]
+        wparams = ",".join(map(lambda x: "?", workshops))
+        iparams = ",".join(map(lambda x: "?", items))
+
+        return [
+            id
+            for (id,) in self.conn.execute(
+                f"""SELECT DISTINCT c.itemid FROM Crafts c
+                    WHERE EXISTS (
+                        SELECT 1 FROM Workshops w
+                        WHERE w.id in ({wparams})
+                        AND '|' || w.crafts || '|' LIKE '%|' || c.id || '|%'
+                    ) AND NOT EXISTS (
+                        SELECT 1 FROM Crafts_Components cc
+                        WHERE cc.id = c.id
+                        AND cc.itemid NOT IN ({iparams})
+                    )""",
+                values,
+            )
+        ]
+
+    def materials(self):
+        return self.conn.execute("SELECT id, color FROM Materials")
+
+    def materials_of_type(self, type):
+        return [mat for (mat,) in self.conn.execute("SELECT id FROM Materials WHERE type = ?", (type,))]
+
+    def plant_harvest_action(self, id):
+        for (action,) in self.conn.execute("SELECT action FROM Plants_OnHarvest WHERE id = ?", (id,)):
+            return action
+        return None
+
+    def plant_material(self, id):
+        for (material,) in self.conn.execute("SELECT material FROM Plants WHERE id = ?", (id,)):
+            return material
+        return None
+
+    def plant_produces(self, id):
+        return self.conn.execute(
+            """SELECT GROUP_CONCAT(chance, '|'), itemid, materialid
+               FROM Plants_OnHarvest_HarvestedItem
+               WHERE id = ?
+               GROUP BY itemid, materialid""",
+            (id,),
+        )
+
+    def plant_types(self):
+        return [type for (type,) in self.conn.execute("SELECT DISTINCT type FROM Plants")]
+
+    def plant_sprites(self, id):
+        return [
+            spriteid
+            for (spriteid,) in self.conn.execute(
+                "SELECT DISTINCT spriteid FROM Plants_States WHERE id = ? AND spriteid != 'none'", (id,)
+            )
+        ]
+
+    def plants(self, type):
+        return self.conn.execute(
+            "SELECT id, growsin, growsinseason, iskilledinseason, losesfruitinseason FROM Plants WHERE type = ?",
+            (type,),
+        )
+
+    def sprite(self, id):
+        # Keep last row only
+        row = None
+        for r in self.conn.execute("SELECT offset, basesprite, tint FROM Sprites WHERE id = ?", (id,)):
+            row = r
+        return row
+
+    def sprite_by_material(self, id):
+        return self.conn.execute(
+            "SELECT basesprite, materialid, sprite, effect FROM Sprites_ByMaterials WHERE id = ?",
+            (id,),
+        )
+
+    def sprite_by_material_type(self, id):
+        return self.conn.execute(
+            """SELECT bmt.basesprite, m.id, bmt.sprite
+               FROM Sprites_ByMaterialTypes bmt
+               JOIN Materials m ON m.type = bmt.materialtype
+               WHERE bmt.id = ?""",
+            (id,),
+        )
+
+    def sprite_combine(self, id):
+        return self.conn.execute(
+            "SELECT basesprite, offset, sprite FROM Sprites_Combine WHERE id = ?",
+            (id,),
+        )
+
+    def sprite_frames(self, id):
+        return self.conn.execute("SELECT DISTINCT basesprite FROM Sprites_Frames WHERE id = ?", (id,))
+
+    def sprite_random(self, id):
+        return self.conn.execute("SELECT basesprite, sprite FROM Sprites_Random WHERE id = ?", (id,))
+
+    def sprite_rotations(self, id):
+        return self.conn.execute("SELECT basesprite, sprite, rotation FROM Sprites_Rotations WHERE id = ?", (id,))
+
+    def sprite_seasons(self, id):
+        return self.conn.execute("SELECT basesprite, season FROM Sprites_Seasons WHERE id = ?", (id,))
+
+    def sprite_seasons_rotations(self, id, season):
+        return self.conn.execute(
+            "SELECT basesprite, rotation FROM Sprites_Seasons_Rotations WHERE id = ?", (f"{id}{season}",)
+        )
+
+    def sprites(self):
+        return [id for (id,) in self.conn.execute("SELECT id FROM Sprites")]
+
+    def translation(self, key):
+        for (text,) in self.conn.execute(
+            "SELECT text FROM Translation WHERE id = ?",
+            (key,),
+        ):
+            return text
+
+    def uncraftable_items(self):
+        return [id for (id,) in self.conn.execute("SELECT id FROM Items EXCEPT SELECT itemid FROM Crafts")]
+
+    def workshop_components(self, id):
+        return self.conn.execute(
+            "SELECT itemid, amount FROM Workshops_Components WHERE id = ? AND amount > 0",
+            (id,),
+        )
+
+    def workshop_requires(self, id):
+        return
+
+    def workshops(self):
+        return self.conn.execute("SELECT id, crafts, tab FROM Workshops")
+
+    def workshops_craftable_with(self, itemids):
+        params = ", ".join(map(lambda x: "?", itemids))
+        return [
+            id
+            for (id,) in self.conn.execute(
+                f"""SELECT w.id FROM Workshops w
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM Workshops_Components c
+                        WHERE c.id = w.id
+                          AND c.amount > 0
+                          AND c.itemid NOT IN ({params})
+                    )""",
+                tuple(itemids),
+            )
+        ]
+
+    def workshops_for_craft(self, craft):
+        return [
+            id
+            for (id,) in self.conn.execute(
+                "SELECT id FROM Workshops WHERE '|' || crafts || '|' LIKE '%|' || ? ||  '|%'",
+                (craft,),
+            )
+        ]
+
+    def workshops_using_item(self, item):
+        return [
+            id
+            for (id,) in self.conn.execute(
+                "SELECT DISTINCT id FROM Workshops_Components WHERE itemid = ?",
+                (item,),
+            )
+        ]
+
+
+db = Database()

--- a/docs/lib/material.py
+++ b/docs/lib/material.py
@@ -1,0 +1,62 @@
+from .db import db
+from .util import empty
+
+
+class MaterialSet:
+    colors = {id: color for (id, color) in db.materials()}
+
+    def __init__(self, materials, types, conversion=None):
+        if not isinstance(materials, list):
+            materials = [] if empty(materials) else materials.split("|")
+
+        if not isinstance(types, list):
+            types = [] if empty(types) else types.split("|")
+
+        if "RandomMetal" in materials:
+            materials.remove("RandomMetal")
+            types.append("Metal")
+
+        types_materials = [m for t in types for m in db.materials_of_type(t)]
+
+        if not empty(conversion) and conversion in materials or conversion in types_materials:
+            materials = [conversion]
+            types = []
+            types_materials = []
+
+        self.all_materials = sorted(set([*materials, *types_materials]))
+        self.labels = [
+            *[f"any {t}" for t in sorted(types)],
+            *sorted([db.translation(f"$MaterialName_{m}") for m in materials]),
+        ]
+
+        idparts = [*[f"M{m}" for m in sorted(materials)], *[f"T{t}" for t in sorted(types)]]
+
+        if len(idparts):
+            self.id = "".join(idparts)
+        else:
+            self.id = "any"
+
+        unique_colors = set()
+        unique_materials = set()
+        for m in self.all_materials:
+            color = MaterialSet.colors[m]
+            if color not in unique_colors:
+                unique_colors.add(color)
+                unique_materials.add(m)
+
+        self.unique_tints = sorted(unique_materials)
+
+    def covers(self, itemid):
+        (mats, mattypes) = db.item_materials(itemid)
+
+        mats = [] if empty(mats) else mats.split("|")
+        mattypes = [] if empty(mattypes) else mattypes.split("|")
+        all_materials = set([*mats, *[m for t in mattypes for m in db.materials_of_type(t)]])
+
+        return all_materials == set(self.all_materials)
+
+    def __eq__(self, other):
+        return other is not None and self.id == other.id
+
+    def __repr__(self):
+        return repr({"type": "MaterialSet", "id": self.id})

--- a/docs/lib/render.py
+++ b/docs/lib/render.py
@@ -1,0 +1,11 @@
+from .themes import themes
+
+
+def render(store, theme, output, build_id):
+    try:
+        ThemeCtor = themes[theme]
+    except KeyError:
+        raise KeyError(f"Theme '{theme}' was not found")
+
+    t = ThemeCtor()
+    t.render(store, output, build_id)

--- a/docs/lib/sprite.py
+++ b/docs/lib/sprite.py
@@ -90,9 +90,11 @@ class Sprite:
             fr = [r for r in rotations if r[2] == "FR"]
             if len(fr) > 0:
                 rotations = fr
-            for (rbase, rsprite, rot) in rotations:
+            for (rbase, rsprite, rot, effect) in rotations:
                 variations.append(
-                    SpriteVariation(BaseSprite.get(rbase) if not empty(rbase) else Sprite.get(rsprite, export=False))
+                    SpriteVariation(
+                        BaseSprite.get(rbase) if not empty(rbase) else Sprite.get(rsprite, export=False), effect=effect
+                    )
                 )
                 break
 
@@ -253,7 +255,10 @@ class BaseSprite(Sprite):
             self.rect = sprite_rect(rect)
 
     def _render(self, **kwargs):
-        return [] if self.missing else [[RenderAlternative(self.id, self.tilesheet, self.rect, **kwargs)]]
+        return [] if self.missing else [[self.alternative(**kwargs)]]
+
+    def alternative(self, **kwargs):
+        return RenderAlternative(self.id, self.tilesheet, self.rect, **kwargs)
 
 
 class SpriteLayer(Sprite):

--- a/docs/lib/sprite.py
+++ b/docs/lib/sprite.py
@@ -1,0 +1,471 @@
+import itertools
+
+from .db import db
+from .util import empty, log, sprite_offset, sprite_offset3d, sprite_rect
+from .material import MaterialSet
+
+
+# Sprites offset overrides for stuff that looks misplaced when using DB data
+# There is most likely an explanation and a better option :)
+offset_overrides = {
+    "Sapling": "0 0",
+    "SoilRampTop": "0 0",
+    "SoilStairsTop": "0 0",
+    "StoneRampTop": "0 0",
+    "StoneStairsTop": "0 0",
+}
+
+# Material set override for sprites that have no default material set
+materialset_overrides = {"Chest": "TWood"}
+
+
+class Sprite:
+    sprites = {}
+    export = set()
+
+    @classmethod
+    def all(cls):
+        return [s.render() for s in cls.sprites.values() if s.id in cls.export]
+
+    @classmethod
+    def get(cls, id, export=True):
+        if empty(id):
+            raise ValueError("Cannot create sprite without an id")
+
+        if id not in cls.sprites:
+            try:
+                cls.sprites[id] = cls._build(id)
+            except ValueError as ex:
+                log(f"In sprite {id}", "! ")
+                raise ex
+
+        if export:
+            cls.export.add(id)
+
+        return cls.sprites[id]
+
+    @classmethod
+    def _build(cls, id):
+        try:
+            (offset, base, tint) = db.sprite(id)
+        except:
+            log(f"No sprite with id={id}", "! ")
+            return EmptySprite(id)
+
+        if id in offset_overrides:
+            offset = offset_overrides[id]
+
+        if empty(tint):
+            tint = None
+
+        variations = []
+        animation = False
+
+        for (mbase, mmat, msprite, effect) in db.sprite_by_material(id):
+            variations.append(
+                SpriteVariation(
+                    BaseSprite.get(mbase) if not empty(mbase) else Sprite.get(msprite, export=False),
+                    material=mmat,
+                    effect=effect,
+                )
+            )
+
+        for (tbase, tmat, tsprite) in db.sprite_by_material_type(id):
+            variations.append(
+                SpriteVariation(
+                    BaseSprite.get(tbase) if not empty(tbase) else Sprite.get(tsprite, export=False), material=tmat
+                )
+            )
+
+        for (rbase, rsprite) in db.sprite_random(id):
+            variations.append(
+                SpriteVariation(
+                    BaseSprite.get(rbase) if not empty(rbase) else Sprite.get(rsprite, export=False),
+                )
+            )
+
+        # Only keep FR rotation (or first available rotation if missing)
+        rotations = list(db.sprite_rotations(id))
+        if len(rotations):
+            fr = [r for r in rotations if r[2] == "FR"]
+            if len(fr) > 0:
+                rotations = fr
+            for (rbase, rsprite, rot) in rotations:
+                variations.append(
+                    SpriteVariation(BaseSprite.get(rbase) if not empty(rbase) else Sprite.get(rsprite, export=False))
+                )
+                break
+
+        # Only keep Spring (or first available season) for season sprites, and only FR (or first rotation) when season rotations are available
+        seasons = list(db.sprite_seasons(id))
+        if len(seasons):
+            spring = [s for s in seasons if s[1] == "Spring"]
+            if len(spring) > 0:
+                seasons = spring
+            for (sbase, season) in seasons:
+                if empty(sbase):
+                    seasons_rotations = list(db.sprite_seasons_rotations(id, season))
+                    if len(seasons_rotations):
+                        fr = [r for r in seasons_rotations if r[1] == "FR"]
+                        if len(fr) > 0:
+                            seasons_rotations = fr
+                        for (srbase, rot) in seasons_rotations:
+                            variations.append(SpriteVariation(BaseSprite.get(srbase)))
+                            break
+                        break
+                else:
+                    variations.append(SpriteVariation(BaseSprite.get(sbase)))
+                    break
+
+        frames = list(db.sprite_frames(id))
+        for (fbase,) in frames:
+            animation = len(frames) > 1
+            variations.append(SpriteVariation(BaseSprite.get(fbase)))
+
+        layers = [
+            SpriteLayer(
+                BaseSprite.get(cbase) if not empty(cbase) else Sprite.get(csprite, export=False),
+                sprite_offset(coffset),
+            )
+            for (cbase, coffset, csprite) in db.sprite_combine(id)
+        ]
+
+        if len(variations) > 0 and len(layers) > 0:
+            raise ValueError(f"Sprite {id} has both variations and combined layers")
+
+        if len(variations) == 0 and len(layers) == 0:
+            variations.append(SpriteVariation(BaseSprite.get(id if empty(base) else base)))
+
+        if len(layers):
+            return LayeredSprite(id, layers, sprite_offset(offset), tint)
+        else:
+            return VariationSprite(id, variations, sprite_offset(offset), tint, animation=animation)
+
+    def __init__(self, id):
+        self.id = id
+        self.material_sets = {}
+        self.default_material_set = None
+
+    def uses_material_set(self, material_set, is_default=False):
+        self.material_sets[material_set.id] = material_set
+
+        if is_default:
+            self.default_material_set = material_set
+            for material in material_set.all_materials:
+                ms = MaterialSet(material, None)
+                self.uses_material_set(ms)
+
+    def uses_material_sets(self, material_sets):
+        self.layer_material_sets = material_sets
+
+    def render(self):
+        layers = [RenderLayer(l) for l in self._render()]
+
+        basesprites = {
+            alt.base: {"rect": alt.rect, "tilesheet": alt.tilesheet} for layer in layers for alt in layer.alternatives
+        }
+
+        def by_material_set(layer, matset):
+            matching_alts = [alt for alt in layer.alternatives if alt.material in matset.all_materials]
+            tintable_alts = [alt for alt in layer.alternatives if alt.material is None and alt.tint == "Material"]
+            if len(matching_alts) == 0 and len(tintable_alts) == 0:
+                return RenderLayer(layer.alternatives)
+            else:
+                return RenderLayer(
+                    [
+                        *matching_alts,
+                        *[alt.tinted(m) for m in matset.unique_tints for alt in tintable_alts],
+                    ]
+                )
+
+        if hasattr(self, "layer_material_sets"):
+            # Different material sets for each layer
+            return {
+                "id": self.id,
+                "basesprites": basesprites,
+                "layer_count": len(layers),
+                "material_sets": [
+                    {
+                        "id": "any",
+                        "names": ["any"],
+                        "layers": [by_material_set(layer, s) for (layer, s) in zip(layers, self.layer_material_sets)],
+                    }
+                ],
+            }
+        else:
+            if self.id in materialset_overrides:
+                self.material_sets["any"] = self.material_sets[materialset_overrides[self.id]]
+                self.default_material_set = self.material_sets["any"]
+
+            return {
+                "id": self.id,
+                "basesprites": basesprites,
+                "layer_count": len(layers),
+                "material_sets": sorted(
+                    [
+                        {
+                            "id": id,
+                            "layers": [by_material_set(layer, s) for layer in layers],
+                            "names": ["any", id] if self.default_material_set == s else [id],
+                        }
+                        for (id, s) in self.material_sets.items()
+                    ],
+                    key=lambda ms: ms["id"],
+                ),
+            }
+
+    def _render(self, **kwargs):
+        raise NotImplemented()
+
+    def __repr__(self):
+        return repr({"type": type(self).__name__, **self.__dict__})
+
+
+class EmptySprite(Sprite):
+    def _render(self, **kwargs):
+        return []
+
+    def __repr__(self):
+        return "Empty"
+
+
+class BaseSprite(Sprite):
+    bases = {}
+
+    @classmethod
+    def get(cls, id):
+        if empty(id):
+            raise ValueError("Cannot create base sprite without an id")
+
+        if id not in cls.bases:
+            cls.bases[id] = BaseSprite(id)
+        return cls.bases[id]
+
+    def __init__(self, id):
+        super().__init__(id)
+        base = db.basesprite(id)
+        if base is None:
+            log(f"No BaseSprite with id={id}", "! ")
+            self.missing = True
+        else:
+            self.missing = False
+            (rect, self.tilesheet) = base
+            self.rect = sprite_rect(rect)
+
+    def _render(self, **kwargs):
+        return [] if self.missing else [[RenderAlternative(self.id, self.tilesheet, self.rect, **kwargs)]]
+
+
+class SpriteLayer(Sprite):
+    def __init__(self, sprite, offset):
+        self.sprite = sprite
+        self.offset = offset
+        if offset is not None:
+            self.ox = offset["x"]
+            self.oy = offset["y"]
+            self.oz = offset["z"]
+
+    def _render(self, ox=0, oy=0, oz=0, **kwargs):
+        if self.offset is not None:
+            ox += self.ox
+            oy += self.oy
+            oz += self.oz
+        return self.sprite._render(ox=ox, oy=oy, oz=oz, **kwargs)
+
+
+class LayeredSprite(Sprite):
+    def __init__(self, id, layers, offset, tint):
+        super().__init__(id)
+        self.layers = layers
+        self.tint = tint
+        self.offset = offset
+        if offset is not None:
+            self.ox = offset["x"]
+            self.oy = offset["y"]
+            self.oz = offset["z"]
+
+    def _render(self, ox=0, oy=0, oz=0, tint=None, **kwargs):
+        if self.tint is not None:
+            tint = self.tint
+        if self.offset is not None:
+            ox += self.ox
+            oy += self.oy
+            oz += self.oz
+        return [l for layer in self.layers for l in layer._render(ox=ox, oy=oy, oz=oz, tint=tint, **kwargs)]
+
+
+class SpriteVariation(Sprite):
+    def __init__(self, sprite, material=None, effect=None, animation=False):
+        self.sprite = sprite
+        self.material = material
+        self.effect = None if effect == "none" else effect
+
+    def _render(self, material=None, effect=None, **kwargs):
+        if self.material is not None:
+            material = self.material
+        if self.effect is not None:
+            effect = self.effect
+        return self.sprite._render(material=material, effect=effect, **kwargs)
+
+
+class VariationSprite(Sprite):
+    def __init__(self, id, variations, offset, tint, animation=False):
+        super().__init__(id)
+        self.variations = variations
+        self.tint = tint
+        self.offset = offset
+        if offset is not None:
+            self.ox = offset["x"]
+            self.oy = offset["y"]
+            self.oz = offset["z"]
+        self.animation = animation
+
+    def _render(self, ox=0, oy=0, oz=0, tint=None, animation=None, **kwargs):
+        if self.tint is not None:
+            tint = self.tint
+        if self.offset is not None:
+            ox += self.ox
+            oy += self.oy
+            oz += self.oz
+
+        vlayers = [
+            v._render(ox=ox, oy=oy, oz=oz, tint=tint, animation=self.animation, **kwargs) for v in self.variations
+        ]
+        layers = []
+        nlayers = max(map(len, vlayers))
+        for l in range(nlayers):
+            layer = []
+            for vls in vlayers:
+                if len(vls) > l:
+                    layer.extend(vls[l])
+
+            layers.append(layer)
+        return layers
+
+
+class PlantSprite(Sprite):
+    @classmethod
+    def get(cls, id):
+        return super().get(f"plant-{id}")
+
+    @classmethod
+    def _build(cls, id):
+        plantid = id.replace("plant-", "")
+        material = db.plant_material(plantid)
+        spriteids = db.plant_sprites(plantid)
+
+        if len(spriteids) > 0:
+            sprite = VariationSprite(
+                id,
+                [SpriteVariation(Sprite.get(spriteid, export=False)) for spriteid in spriteids],
+                None,
+                None,
+            )
+
+            sprite.uses_material_set(MaterialSet(material, None), is_default=True)
+            return sprite
+        else:
+            log(f"No sprite for plant id={plantid}", "! ")
+            return EmptySprite(id)
+
+
+class ConstructionSprite(Sprite):
+    @classmethod
+    def get(cls, id):
+        return super().get(f"constr-{id}")
+
+    @classmethod
+    def _build(cls, id):
+        constrid = id.replace("constr-", "")
+        sprites = list(db.construction_sprites(constrid))
+
+        if len(sprites) > 0:
+            sprite = LayeredSprite(
+                id,
+                [
+                    SpriteLayer(Sprite.get(spriteid, export=False), sprite_offset3d(offset))
+                    for (spriteid, offset) in sprites
+                ],
+                None,
+                None,
+            )
+
+            return sprite
+        else:
+            return Sprite.get(constrid)
+
+
+class RenderLayer:
+    def __init__(self, alternatives):
+        self.alternatives = alternatives
+
+    def common(self):
+        """Return a dict with info that is common for all alternatives in the layer"""
+
+        attrs = ["tilesheet", "ox", "oy", "effect"]
+        rect = ["w", "h", "x", "y"]
+        common = {}
+
+        for attr in attrs:
+            values = set([getattr(alt, attr) for alt in self.alternatives])
+            if len(values) == 1:
+                common[attr] = values.pop()
+
+        for attr in rect:
+            values = set([alt.rect[attr] for alt in self.alternatives])
+            if len(values) == 1:
+                common[f"rect{attr}"] = values.pop()
+
+        return common
+
+    def unique(self):
+        """Returns a list of unique alternatives, taking tint colors into account"""
+        unique_reprs = set()
+        unique_alts = []
+
+        for alt in self.alternatives:
+            r = repr(alt.tinted(MaterialSet.colors[alt.material])) if alt.material in MaterialSet.colors else repr(alt)
+            if r not in unique_reprs:
+                unique_reprs.add(r)
+                unique_alts.append(alt)
+
+        return unique_alts
+
+    def __repr__(self):
+        return repr({"type": "RenderLayer", "alts": self.alternatives})
+
+
+class RenderAlternative:
+    def __init__(self, base, tilesheet, rect, ox=0, oy=0, oz=0, tint=None, material=None, effect=None, animation=False):
+        self.base = base
+        self.tilesheet = tilesheet
+        self.rect = rect
+        self.ox = ox
+        self.oy = oy - 20 * oz
+        self.tint = tint
+        self.material = material
+        self.effect = effect
+        self.animation = animation
+
+    def tinted(self, material):
+        return RenderAlternative(
+            self.base,
+            self.tilesheet,
+            self.rect,
+            self.ox,
+            self.oy,
+            0,
+            self.tint,
+            material,
+            self.effect,
+            self.animation,
+        )
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+    def __hash__(self):
+        return hash((self.base, self.ox, self.oy, self.tint, self.material, self.effect))
+
+    def __repr__(self):
+        return repr({"type": "RenderAlternative", **self.__dict__})

--- a/docs/lib/store.py
+++ b/docs/lib/store.py
@@ -1,0 +1,466 @@
+from .db import db
+from .material import MaterialSet
+from .sprite import ConstructionSprite, PlantSprite, Sprite
+from .util import empty, log, sort_translations, total_amount, amount_hint
+
+
+class Store:
+    def category_groups(self, cat):
+        return sort_translations(
+            [
+                {
+                    "id": group,
+                    "translation": self.translate("group", group),
+                    "items": self.group_items(cat, group),
+                }
+                for group in db.item_groups(cat)
+            ]
+        )
+
+    def categories(self):
+        return sort_translations(
+            [
+                {
+                    "id": cat,
+                    "translation": self.translate("category", cat),
+                    "groups": self.category_groups(cat),
+                }
+                for cat in db.categories()
+            ]
+        )
+
+    def categorize(self, items):
+        return sort_translations(
+            [
+                {
+                    "id": cat,
+                    "translation": self.translate("category", cat),
+                    "groups": sort_translations(
+                        [
+                            {
+                                "id": group,
+                                "translation": self.translate("group", group),
+                                "items": [item for item in items if item["cat"] == cat and item["group"] == group],
+                            }
+                            for group in set([item["group"] for item in items if item["cat"] == cat])
+                        ]
+                    ),
+                }
+                for cat in set([item["cat"] for item in items])
+            ]
+        )
+
+    def construction(self, id):
+        (category, type) = db.construction(id)
+        if category is None:
+            category = type
+
+        components = self.construction_components(id)
+        if len(components) == 0:
+            log(f"Empty construction {id}", "! ")
+            return None
+
+        if len(components) == 1:
+            matset = components[0]["material_set"]
+            sprite = self.construction_sprite(id, matset=matset)
+        else:
+            matsets = [c["material_set"] for c in components]
+            sprite = self.construction_sprite(id, matsets=matsets)
+            matset = {"id": "any"}
+
+        return {
+            "id": id,
+            "translation": self.translate("construction", id),
+            "sprite": sprite,
+            "material_set": matset,
+            "components": sort_translations(components),
+            "category": category,
+            "type": type,
+        }
+
+    def construction_component(self, itemid, amount, mats, mattypes):
+        matset = MaterialSet(mats, mattypes)
+
+        if matset.id == "any":
+            (materials, mattypes) = db.item_materials(itemid)
+            matset = MaterialSet(materials, mattypes)
+
+        return {
+            "id": itemid,
+            "translation": self.translate("item", itemid),
+            "sprite": self.item_sprite(itemid, register=matset),
+            "material_set": matset,
+            "amount": int(amount),
+        }
+
+    def construction_components(self, id):
+        return [self.construction_component(*row) for row in db.construction_components(id)]
+
+    def construction_sprite(self, id, matset=None, matsets=None):
+        sprite = ConstructionSprite.get(id)
+
+        if matset is not None:
+            sprite.uses_material_set(matset)
+        if matsets is not None:
+            sprite.uses_material_sets(matsets)
+
+        return sprite.id
+
+    def constructions(self):
+        constructions = [c for c in [self.construction(id) for id in db.constructions()] if c is not None]
+
+        return [
+            {"category": cat, "constructions": sort_translations([c for c in constructions if c["category"] == cat])}
+            for cat in sorted(set([c["category"] for c in constructions]))
+        ]
+
+    def container(self, id):
+        if empty(id):
+            return None
+
+        row = db.container(id)
+        if row is None:
+            return None
+
+        (capacity, same) = row
+
+        return {
+            "id": id,
+            "translation": self.translate("item", id),
+            "sprite": self.item_sprite(id),
+            "capacity": int(capacity),
+            "same": int(same) == 1,
+        }
+
+    def container_items(self, id):
+        return self.categorize(
+            [
+                {
+                    "id": item,
+                    "cat": cat,
+                    "group": group,
+                    "translation": self.translate("item", item),
+                    "sprite": self.item_sprite(item),
+                }
+                for (item, sprite, cat, group) in db.container_items(id)
+            ]
+        )
+
+    def craft_component(self, amount, itemid, mats, mattypes):
+        matset = MaterialSet(mats, mattypes)
+        return {
+            "id": itemid,
+            "translation": self.translate("item", itemid),
+            "sprite": self.item_sprite(itemid, register=matset),
+            "material_set": matset,
+            "amount": int(amount),
+        }
+
+    def craft_components(self, craft):
+        return sort_translations([self.craft_component(*row) for row in db.craft_components(craft)])
+
+    def craft_workshops(self, craft):
+        return sort_translations(
+            [{"id": id, "translation": self.translate("workshop", id)} for id in db.workshops_for_craft(craft)]
+        )
+
+    def craft(self, id, itemid, amount, time, skill, rmats, rmattypes, rconv):
+        matset = MaterialSet(rmats, rmattypes, rconv)
+        return {
+            "id": itemid,
+            "translation": "none" if itemid is None else self.translate("item", itemid),
+            "sprite": None if itemid is None else self.item_sprite(itemid, register=matset),
+            "material_set": matset,
+            "time": int(time),
+            "skill": self.translate("skill", skill),
+            "components": self.craft_components(id),
+            "workshops": self.craft_workshops(id),
+            "amount": int(amount),
+        }
+
+    def drinks(self):
+        return self.categorize(
+            [
+                {
+                    "id": item,
+                    "cat": cat,
+                    "group": group,
+                    "translation": self.translate("item", item),
+                    "sprite": self.item_sprite(item),
+                    "drinkvalue": drinkval,
+                }
+                for (item, sprite, cat, group, drinkval) in db.drink_items()
+            ]
+        )
+
+    def food(self):
+        return self.categorize(
+            [
+                {
+                    "id": item,
+                    "cat": cat,
+                    "group": group,
+                    "translation": self.translate("item", item),
+                    "sprite": self.item_sprite(item),
+                    "eatvalue": eatval,
+                }
+                for (item, sprite, cat, group, eatval) in db.food_items()
+            ]
+        )
+
+    def group_items(self, cat, group):
+        return sort_translations(
+            [
+                {"id": item, "translation": self.translate("item", item), "sprite": self.item_sprite(item)}
+                for (item, sprite, _, _) in db.group_items(cat, group)
+            ]
+        )
+
+    def item(self, id, cat, group, stack, value, evalue, dvalue, light, mats, mattypes, cnt, ccnt, sprite):
+        containerinfo = {}
+        if cat == "Containers":
+            containerinfo = self.container(id)
+            containerinfo["can_contain"] = self.container_items(id)
+
+        return {
+            "id": id,
+            "translation": self.translate("item", id),
+            "group": {
+                "id": group,
+                "translation": self.translate("group", group),
+            },
+            "category": {
+                "id": cat,
+                "translation": self.translate("category", cat),
+            },
+            "stack": stack,
+            "container": self.container(cnt),
+            "carry": self.container(ccnt),
+            "sprite": self.item_sprite(id),
+            "materials": self.material_tree(mats, mattypes),
+            "value": value,
+            "evalue": evalue,
+            "dvalue": dvalue,
+            "light": light,
+            "crafts": self.item_crafts(id),
+            "rcrafts": self.item_rcrafts(id),
+            "wcrafts": self.item_wcrafts(id),
+            "constructions": self.item_constructions(id),
+            "rconstructions": self.item_rconstructions(id),
+            **containerinfo,
+        }
+
+    def item_constructions(self, item):
+        constructions = [self.construction(id) for id in db.constructions_for_item(item)]
+
+        return [
+            {"category": cat, "constructions": sort_translations([c for c in constructions if c["category"] == cat])}
+            for cat in sorted(set([c["category"] for c in constructions]))
+        ]
+
+    def item_rconstructions(self, item):
+        constructions = [self.construction(id) for id in db.constructions_using_item(item)]
+
+        return [
+            {"category": cat, "constructions": sort_translations([c for c in constructions if c["category"] == cat])}
+            for cat in sorted(set([c["category"] for c in constructions]))
+        ]
+
+    def item_crafts(self, item):
+        return [
+            self.craft(id, item, amount, time, skill, rmats, rmattypes, rconv)
+            for (id, amount, time, skill, rmats, rmattypes, rconv) in db.item_crafts(item)
+        ]
+
+    def item_rcraft(self, craft):
+        row = db.craft(craft)
+        return None if row is None else self.craft(*row)
+
+    def item_rcrafts(self, item):
+        return list(filter(lambda c: c is not None, [self.item_rcraft(craft) for craft in db.crafts_using_item(item)]))
+
+    def item_wcrafts(self, item):
+        return [{"id": id, "translation": self.translate("workshop", id)} for id in db.workshops_using_item(item)]
+
+    def item_sprite(self, item, register=None):
+        sprite = db.item_sprite(item)
+        (materials, mattypes) = db.item_materials(item)
+
+        spriteObj = Sprite.get(item if sprite is None else sprite)
+
+        matset = MaterialSet(materials, mattypes)
+        spriteObj.uses_material_set(matset, is_default=True)
+
+        # Register caller-specific material set
+        if register is not None:
+            spriteObj.uses_material_set(register)
+
+        return item if sprite is None else sprite
+
+    def items(self):
+        return sort_translations([self.item(*row) for row in db.items()])
+
+    def materials(self, mats, mattypes):
+        mats = [] if mats is None else mats.split("|")
+        mattypes = [] if mattypes is None else mattypes.split("|")
+
+        return sort_translations(
+            [
+                {"id": id, "translation": self.translate("material", id)}
+                for id in [
+                    *mats,
+                    *[mat for type in mattypes for mat in db.materials_of_type(type)],
+                ]
+            ]
+        )
+
+    def material_tree(self, mats, mattypes):
+        mattypes = [] if mattypes is None else mattypes.split("|")
+        return sort_translations(
+            [
+                *(
+                    []
+                    if mats is None
+                    else [
+                        {
+                            "id": "Other",
+                            "materials": sort_translations(
+                                [{"id": mat, "translation": self.translate("material", mat)} for mat in mats.split("|")]
+                            ),
+                        }
+                    ]
+                ),
+                *[
+                    {
+                        "id": type,
+                        "materials": sort_translations(
+                            [
+                                {"id": mat, "translation": self.translate("material", mat)}
+                                for mat in db.materials_of_type(type)
+                            ]
+                        ),
+                    }
+                    for type in mattypes
+                ],
+            ]
+        )
+
+    def plant_produce(self, chance, itemid, materialid):
+        matset = MaterialSet(materialid, None)
+        return {
+            "id": itemid,
+            "translation": self.translate("item", itemid),
+            "sprite": self.item_sprite(itemid, register=matset),
+            "material_set": matset,
+            "amount": total_amount(chance),
+            "amount_hint": amount_hint(chance),
+        }
+
+    def plant_produces(self, id):
+        return [self.plant_produce(*row) for row in db.plant_produces(id)]
+
+    def plant_sprite(self, id):
+        sprite = PlantSprite.get(id)
+        return sprite.id
+
+    def plants(self):
+        floors = {"Tree": "grass", "Mushroom": "grass"}
+
+        return [
+            {
+                "type": type,
+                "floor": floors.get(type, "farm"),
+                "plants": sort_translations(
+                    [
+                        {
+                            "id": id,
+                            "sprite": self.plant_sprite(id),
+                            "growsin": growsin,
+                            "growseason": [] if growseason is None else growseason.split("|"),
+                            "killseason": [] if killseason is None else killseason.split("|"),
+                            "loseseason": [] if loseseason is None else loseseason.split("|"),
+                            "harvestaction": db.plant_harvest_action(id),
+                            "harvestproduces": self.plant_produces(id),
+                        }
+                        for (id, growsin, growseason, killseason, loseseason) in db.plants(type)
+                    ]
+                ),
+            }
+            for type in db.plant_types()
+        ]
+
+    def sprites(self):
+        """This method should be the last store method call made in themes, as other
+        store methods may register new sprites or register new materials on sprites."""
+        return Sprite.all()
+
+    def tints(self):
+        return [
+            {
+                "id": id,
+                "r": int(color.split(" ")[0]),
+                "g": int(color.split(" ")[1]),
+                "b": int(color.split(" ")[2]),
+                "a": int(color.split(" ")[3]),
+            }
+            for (id, color) in db.materials()
+        ]
+
+    def translate(self, type, id):
+        text = db.translation(f"${type.capitalize()}Name_{id}")
+        return id if text is None else text
+
+    def workshop_components(self, id):
+        return sort_translations(
+            [
+                {
+                    "id": itemid,
+                    "translation": self.translate("item", itemid),
+                    "sprite": self.item_sprite(itemid),
+                    "amount": int(amount),
+                    "workshops": sort_translations(
+                        map(
+                            lambda w: {"id": w, "translation": self.translate("workshop", w)},
+                            set(
+                                [
+                                    wid
+                                    for (craftid, amount, time, skill, _, _, _) in db.item_crafts(itemid)
+                                    for wid in db.workshops_for_craft(craftid)
+                                    if id != wid
+                                ],
+                            ),
+                        )
+                    ),
+                }
+                for (itemid, amount) in db.workshop_components(id)
+            ]
+        )
+
+    def workshop_craft(self, craft):
+        row = db.craft(craft)
+        return None if row is None else self.craft(*row)
+
+    def workshop_crafts(self, crafts):
+        if crafts is None:
+            return []
+
+        return sort_translations(
+            filter(
+                lambda c: c is not None,
+                [self.workshop_craft(craft) for craft in crafts.split("|")],
+            )
+        )
+
+    def workshops(self):
+        return sort_translations(
+            [
+                {
+                    "id": id,
+                    "translation": self.translate("workshop", id),
+                    "crafts": self.workshop_crafts(crafts),
+                    "components": self.workshop_components(id),
+                    "tab": tab,
+                }
+                for (id, crafts, tab) in db.workshops()
+            ]
+        )

--- a/docs/lib/themes/__init__.py
+++ b/docs/lib/themes/__init__.py
@@ -1,0 +1,3 @@
+from .default.theme import DefaultTheme
+
+themes = {"default": DefaultTheme}

--- a/docs/lib/themes/default/assets/doc.js
+++ b/docs/lib/themes/default/assets/doc.js
@@ -1,0 +1,101 @@
+function setupSearch() {
+  let input = document.querySelector('input[type="search"]')
+  let queryDisplay = document.querySelector('.search-query')
+  let results = document.querySelector('section.search-results')
+  let noResults = document.querySelector('.no-results')
+  let content = document.querySelector('section.content')
+
+  let entries = [
+    ...document.querySelectorAll('.search-results li[data-keywords]')
+  ].map((e) => ({
+    element: e,
+    keywords: e.getAttribute('data-keywords').toLowerCase().replace(/ /g, '')
+  }))
+
+  function search(e) {
+    let { value } = input
+
+    if (value) {
+      queryDisplay.textContent = value
+
+      let query = value.toLowerCase().replace(/ /g, '')
+      let firstMatch = null
+      let matchCount = 0
+
+      for (let { element, keywords } of entries) {
+        if (keywords.includes(query)) {
+          matchCount++
+
+          if (!firstMatch) {
+            firstMatch = element
+          }
+
+          element.style.display = 'list-item'
+        } else {
+          element.style.display = 'none'
+        }
+      }
+
+      noResults.style.display = matchCount > 0 ? 'none' : 'block'
+
+      results.style.display = 'block'
+      content.style.display = 'none'
+
+      if (firstMatch && e.keyCode === 13) {
+        firstMatch.querySelector('a').click()
+      }
+    } else {
+      results.style.display = 'none'
+      content.style.display = 'block'
+    }
+  }
+
+  input.value = ''
+  input.addEventListener('keyup', search)
+  input.addEventListener('change', search)
+}
+
+function setupCollapse() {
+  for (let header of document.querySelectorAll('[data-collapse]')) {
+    let group = header.getAttribute('data-collapse')
+    let trigger = document.createElement('a')
+
+    trigger.className = 'collapse-trigger'
+    trigger.href = '#'
+    trigger.setAttribute('data-collapsed', 'false')
+    trigger.textContent = '(collapse)'
+
+    trigger.addEventListener('click', (e) => {
+      e.preventDefault()
+
+      let collapsed = trigger.getAttribute('data-collapsed')
+      if (collapsed === 'true') {
+        trigger.setAttribute('data-collapsed', 'false')
+        trigger.textContent = '(collapse)'
+
+        for (let elem of document.querySelectorAll(
+          `[data-collapse-group="${group}"]`
+        )) {
+          elem.style.display = 'table-row'
+        }
+      } else {
+        trigger.setAttribute('data-collapsed', 'true')
+        trigger.textContent = '(expand)'
+
+        for (let elem of document.querySelectorAll(
+          `[data-collapse-group="${group}"]`
+        )) {
+          elem.style.display = 'none'
+        }
+      }
+    })
+
+    header.appendChild(trigger)
+    trigger.click()
+  }
+}
+
+;(function () {
+  setupSearch()
+  setupCollapse()
+})()

--- a/docs/lib/themes/default/assets/style.css
+++ b/docs/lib/themes/default/assets/style.css
@@ -1,0 +1,230 @@
+/* Global styles */
+
+:root {
+  --color-fade: #888;
+  --color-text: #444;
+  --color-hover: #111;
+  --color-bg: #eee;
+  --color-bg-alt: #f8f8f8;
+  --color-bg-tables: #fff;
+  --color-border: #aaa;
+
+  --layout-width: 1000px;
+  --layout-nav: 200px;
+
+  --font-size: 0.8rem;
+  --font-size-menu: calc(var(--font-size) * 1.25);
+
+  --margin-large: 1rem;
+  --margin-mid: calc(var(--margin-large) / 2);
+  --margin-small: calc(var(--margin-large) / 5);
+  --margin-tiny: calc(var(--margin-large) / 10);
+  --margin-icon: calc(3 * var(--margin-large));
+}
+
+body {
+  margin: 0;
+
+  font-family: sans-serif;
+  font-size: var(--font-size);
+
+  color: var(--color-text);
+  background-color: var(--color-bg);
+}
+
+li {
+  list-style: square;
+}
+
+a {
+  text-decoration: none;
+}
+
+a:link,
+a:visited,
+a:active {
+  color: var(--color-text);
+  border-bottom: 1px dotted var(--color-text);
+}
+
+a:hover {
+  color: var(--color-hover);
+  border-bottom: 1px solid var(--color-hover);
+}
+
+a.hint,
+a.hint:hover {
+  color: var(--color-text);
+  border-bottom: 1px dotted var(--color-text);
+  cursor: help;
+}
+
+/* Layout */
+
+section.container,
+table.nav,
+footer {
+  margin: var(--margin-large) auto;
+  max-width: var(--layout-width);
+  width: 100%;
+}
+
+section.container {
+  display: flex;
+  flex-flow: row nowrap;
+}
+
+nav {
+  width: var(--layout-nav);
+  margin-right: var(--margin-large);
+}
+
+section.content,
+section.search-results {
+  flex-grow: 1;
+}
+
+section.search-results {
+  display: none;
+}
+
+footer {
+  color: var(--color-fade);
+  text-align: center;
+  font-style: italic;
+}
+
+/* Navbar */
+
+nav .icon {
+  margin: var(--margin-large) var(--margin-icon);
+  max-width: calc(var(--layout-nav) - 2 * var(--margin-icon));
+  image-rendering: crisp-edges;
+  image-rendering: pixelated;
+}
+
+nav input {
+  border: 1px solid var(--color-border);
+  margin-bottom: var(--margin-large);
+  width: 100%;
+}
+
+nav ul {
+  padding: 0;
+}
+
+nav li {
+  margin: var(--margin-mid) 0;
+  list-style: none;
+  font-weight: bold;
+  font-size: var(--font-size-menu);
+}
+
+/* Tables */
+
+table {
+  border-spacing: 0;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-bg-tables);
+}
+
+td.number {
+  text-align: center;
+}
+
+td {
+  padding: var(--margin-small);
+}
+
+th {
+  background-color: var(--color-bg);
+  padding: var(--margin-tiny) var(--margin-small);
+  border: var(--margin-tiny) solid var(--color-bg-tables);
+
+  text-align: center;
+}
+
+/* Navtable */
+
+table.nav th.category,
+table.nav th.group {
+  white-space: nowrap;
+}
+
+table.nav th.group,
+table.nav th.group a {
+  color: var(--color-fade);
+}
+
+table.nav a.collapse-trigger {
+  margin-left: var(--margin-mid);
+  font-weight: normal;
+}
+
+/* Craft tables */
+
+table.workshop-components tr:nth-child(2n + 1),
+table.workshops tr:nth-child(2n + 1),
+table.crafts tr:nth-child(2n + 1),
+table.constructions tr:nth-child(2n + 1) {
+  background-color: var(--color-bg-alt);
+}
+
+table.crafts .single td {
+  vertical-align: bottom;
+}
+
+/* Plant tables */
+
+table.plants {
+  width: 100%;
+}
+
+table.plants tr:nth-child(2n + 1) {
+  background-color: var(--color-bg-alt);
+}
+
+table.plants td.seasons {
+  text-align: center;
+}
+
+/* Misc */
+
+h2 .sprite {
+  float: right;
+}
+
+h2 .type {
+  font-weight: normal;
+  font-style: italic;
+  color: var(--color-fade);
+}
+
+h2 .type:after {
+  content: ': ';
+}
+
+table.iteminfo {
+  width: 100%;
+}
+
+table.iteminfo th {
+  white-space: nowrap;
+}
+
+table.item-materials {
+  width: 100%;
+}
+
+.buildlist {
+  display: flex;
+  flex-flow: row;
+}
+
+.buildlist table + table {
+  margin-left: var(--margin-large);
+}
+
+.entry {
+  white-space: nowrap;
+}

--- a/docs/lib/themes/default/base.html.j2
+++ b/docs/lib/themes/default/base.html.j2
@@ -1,6 +1,5 @@
-{% import "macros.html.j2" as macros with context %}
-
 <!DOCTYPE html>
+{% import "macros.html.j2" as macros with context %}
 <head>
   <title>{% block title %}Ingnomia docs{% endblock %}</title>
 

--- a/docs/lib/themes/default/base.html.j2
+++ b/docs/lib/themes/default/base.html.j2
@@ -1,0 +1,71 @@
+{% import "macros.html.j2" as macros with context %}
+
+<!DOCTYPE html>
+<head>
+  <title>{% block title %}Ingnomia docs{% endblock %}</title>
+
+  <link rel="stylesheet" type="text/css" href="{{ base }}assets/style.css" />
+  <link rel="stylesheet" type="text/css" href="{{ base }}assets/sprites.css" />
+  <link rel="shortcut icon" href="{{ base }}assets/icon.png" />
+</head>
+<body>
+  <section class="container">
+    <nav>
+      <a href="{{ base }}index.html">
+        <img class="icon" src="{{ base }}assets/icon.png">
+      </a>
+
+      <input type="search" placeholder="Quick search...">
+
+      <ul>
+        <li>
+          {{ macros.sprite("Crate", matset="MOak", background="plain") }}
+          <a href="{{ base }}items.html">Items</a>
+        </li>
+        <li>
+          {{ macros.sprite("ShepherdsPie", background="wood") }}
+          <a href="{{ base }}food.html">Food</a>
+        </li>
+        <li>
+          {{ macros.sprite("plant-Tomato", background="grass", step=2) }}
+          <a href="{{ base }}plants.html">Plants</a>
+        </li>
+        <li>
+          {{ macros.sprite("constr-BlockStairs", matset="TStone", step=7) }}
+          <a href="{{ base }}constructions.html">Constructions</a>
+        </li>
+        <li>
+          {{ macros.sprite("Workbench", matset="MPine", background="stone") }}
+          <a href="{{ base }}workshops.html">Workshops</a>
+        </li>
+      </ul>
+    </nav>
+
+    <section class="content">
+      {% block content %}{% endblock %}
+    </section>
+
+    <section class="search-results">
+      <h2>Search results for "<span class="search-query"></span>"</h2>
+
+      <span class="no-results">No results :(</span>
+
+      <ul>
+        {% for item in index %}
+          <li data-keywords="{{ item.kw }}"><a href="{{ base }}{{ item.href }}">{{ item.type|title }}: {{ item.label|title }}</a></li>
+        {% endfor %}
+      </ul>
+    </section>
+  </section>
+
+  {{ navtable_rendered }}
+
+  <footer>
+    <div>
+      Generated on {{ build.date }} UTC
+      {% if build.id %}from version {{ build.id }}{% endif %}
+    </div>
+  </footer>
+
+  <script src="{{ base }}assets/doc.js"></script>
+</body>

--- a/docs/lib/themes/default/constructions.html.j2
+++ b/docs/lib/themes/default/constructions.html.j2
@@ -1,0 +1,12 @@
+{% extends "base.html.j2" %}
+{% import "macros.html.j2" as macros with context %}
+
+{% block title %}
+  All Constructions - {{ super() }}
+{% endblock %}
+
+{% block content %}
+  <h2>All Constructions</h2>
+
+  {{ macros.constrlist(constructions) }}
+{% endblock %}

--- a/docs/lib/themes/default/food.html.j2
+++ b/docs/lib/themes/default/food.html.j2
@@ -1,0 +1,52 @@
+{% extends "base.html.j2" %}
+{% import "macros.html.j2" as macros with context %}
+
+
+{% macro food_table(data, value_label, value_attr) %}
+  <table class="food">
+    <tr>
+      <th colspan="2">Items</th>
+      <th>{{ value_label }}</th>
+    </tr>
+    {% for category in data %}
+      {% for group in category.groups %}
+        {% for item in group["items"] %}
+          <tr>
+            {% if loop.index == 1 %}
+              <th class="category" rowspan="{{ loop.length }}">
+                {{ group.translation|title }}
+              </th>
+            {% endif %}
+
+            <td>
+              {% if item.sprite %}
+                {{ macros.sprite(item.sprite) }}
+              {% endif %}
+              <a href="{{ base }}item/{{ item.id }}.html">{{ item.translation|title }}</a>
+            </td>
+
+            <td class="number">
+              {{ item[value_attr] }}
+            </td>
+          </tr>
+        {% endfor %}
+      {% endfor %}
+    {% endfor %}
+  </table>
+{% endmacro %}
+
+{% block title %}
+  All Food & Drinks - {{ super() }}
+{% endblock %}
+
+{% block content %}
+  <h2>All Food & Drinks</h2>
+
+  <h3>Food</h3>
+
+  {{ food_table(data=food, value_label="Eat value", value_attr="eatvalue") }}
+
+  <h3>Drinks</h3>
+
+  {{ food_table(data=drinks, value_label="Drink value", value_attr="drinkvalue") }}
+{% endblock %}

--- a/docs/lib/themes/default/index.html.j2
+++ b/docs/lib/themes/default/index.html.j2
@@ -1,0 +1,7 @@
+{% extends "base.html.j2" %}
+
+{% block content %}
+  <h2>Auto-generated documentation for Ingnomia</h2>
+
+  Use the menu, the table below or the search box to navigate.
+{% endblock %}

--- a/docs/lib/themes/default/item.html.j2
+++ b/docs/lib/themes/default/item.html.j2
@@ -1,0 +1,150 @@
+{% extends "base.html.j2" %}
+{% import "macros.html.j2" as macros with context %}
+
+{% block title %}
+  {{ item.translation|title }} - {{ super() }}
+{% endblock %}
+
+{% block content %}
+  <h2>
+    <span class="type">Item</span>
+    {{ item.translation|title }}
+  </h2>
+
+  <table class="iteminfo">
+    <tr>
+      <th>Category</th>
+      <td>{{ item.category.translation|title }}</td>
+      <td rowspan="0">
+        {{ macros.sprite(item.sprite, zoom=true, background="grass") }}
+      </td>
+    </tr>
+    <tr>
+      <th>Group</th>
+      <td>{{ item.group.translation|title }}</td>
+    </tr>
+    <tr>
+      <th>Storage</th>
+      <td>
+        {% if item.stack %}
+          <div>
+            {% if item.stack == 1 %}
+              Does not stack
+            {% else %}
+              Stacks by {{ item.stack }}
+            {% endif %}
+
+            on the ground
+          </div>
+        {% endif %}
+        {% if item.container %}
+          <div>{{ macros.item(item.container) }} <i>(max. {{ item.container.capacity }}, in stockpiles)</i></div>
+        {% endif %}
+        {% if item.carry %}
+          <div>{{ macros.item(item.carry) }} <i>(max. {{ item.carry.capacity }}, for carrying)</i></div>
+        {% endif %}
+      </td>
+    </tr>
+    {% if item.capacity %}
+      <tr>
+        <th>Capacity</th>
+        <td>{{ item.capacity }} {% if item.same %}identical{% else %}varied{% endif %} items</td>
+      </tr>
+    {% endif %}
+    <tr>
+      <th>Value</th>
+      <td>{{ item.value }}</td>
+    </tr>
+    {% if item.evalue %}
+      <tr>
+        <th>Eat value</th>
+        <td>{{ item.evalue }}</td>
+      </tr>
+    {% endif %}
+    {% if item.dvalue %}
+      <tr>
+        <th>Drink value</th>
+        <td>{{ item.dvalue }}</td>
+      </tr>
+    {% endif %}
+    {% if item.light %}
+      <tr>
+        <th>Light intensity</th>
+        <td>{{ item.light }}</td>
+      </tr>
+    {% endif %}
+  </table>
+
+  {% if item.materials|length %}
+    <h3>Materials</h3>
+
+    <table class="item-materials">
+      {% for type in item.materials %}
+        <tr>
+          <th>{{ type.id }}</th>
+          <td>
+            {% for mat in type.materials %}
+              <span class="entry">
+                {{ macros.sprite(item.sprite, matset="M" ~ mat.id) }}
+                {{ mat.translation|title }}
+                {% if not loop.last %}
+                  &bull;
+                {% endif %}
+              </span>
+            {% endfor %}
+          </td>
+        </tr>
+      {% endfor %}
+    </table>
+  {% endif %}
+
+  {% if item.crafts|length %}
+    <h3>Crafting recipes</h3>
+
+    {{ macros.craftlist(item.crafts) }}
+  {% endif %}
+
+  {% if item.constructions|length %}
+    <h3>Construction recipes</h3>
+
+    {{ macros.constrlist(item.constructions) }}
+  {% endif %}
+
+  {% if item.rcrafts|length %}
+    <h3>Used to craft</h3>
+
+    {{ macros.craftlist(item.rcrafts) }}
+  {% endif %}
+
+  {% if item.wcrafts|length or item.rconstructions|length %}
+    <h3>Used to build</h3>
+
+    <div class="buildlist">
+      {% if item.rconstructions|length %}
+        {{ macros.constrlist(item.rconstructions) }}
+      {% endif %}
+
+      {% if item.wcrafts|length %}
+        <table class="workshops">
+          <tr>
+            <th>Workshop</th>
+          </tr>
+
+          {% for workshop in item.wcrafts %}
+            <tr>
+              <td>
+                <a href="{{ base }}workshop/{{ workshop.id }}.html">{{ workshop.translation|title }}</a>
+              </td>
+            </tr>
+          {% endfor %}
+        </table>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  {% if item.can_contain %}
+    <h3>Allowed items in container</h3>
+
+    {{ macros.nav_table(custom_data=item.can_contain, custom_path="item", class="") }}
+  {% endif %}
+{% endblock %}

--- a/docs/lib/themes/default/items.html.j2
+++ b/docs/lib/themes/default/items.html.j2
@@ -1,0 +1,12 @@
+{% extends "base.html.j2" %}
+{% import "macros.html.j2" as macros with context %}
+
+{% block title %}
+  All Items - {{ super() }}
+{% endblock %}
+
+{% block content %}
+  <h2>All Items</h2>
+
+  {{ macros.nav_table(only_section="Items", class="") }}
+{% endblock %}

--- a/docs/lib/themes/default/macros.html.j2
+++ b/docs/lib/themes/default/macros.html.j2
@@ -1,0 +1,184 @@
+{% macro sprite(sprite, matset=None, background="plain", zoom=false, step=None) %}
+  {% if sprite is string %}
+    {% set sprite = sprites|selectattr("id", "equalto", sprite)|first %}
+  {% endif %}
+
+  {% if sprite %}
+    {% if not matset %}
+      {% set matset = "any" %}
+    {% endif %}
+
+    <span
+      class="
+        sprite
+        s-{{ sprite.id }}
+        m-{{ matset }}
+        {% if zoom %}zoomed{% endif %}
+      ">
+      {% if background %}
+        <span class="bg bg-{{ background }}"></span>
+      {% endif %}
+
+      <span class="layers">
+        {% for layer in range(sprite.layer_count) %}
+          <span
+            class="layer"
+            {% if step %}
+              style="animation-play-state: paused; animation-delay: -{{ step - 1 }}s;"
+            {% endif %}
+          ></span>
+        {% endfor %}
+      </span>
+    </span>
+  {% endif %}
+{% endmacro %}
+
+{% macro item(i) %}
+  {% if i.sprite %}
+    {% if i.material_set %}
+      {% set matset = i.material_set.id %}
+    {% else %}
+      {% set matset = "any" %}
+    {% endif %}
+    {{ sprite(i.sprite, matset=matset) }}
+  {% endif %}
+  <a href="{{ base }}item/{{ i.id }}.html">
+    {{ i.translation|title }}{% if i.material_set and i.material_set.labels|length and not i.material_set.covers(i.id) %}
+      ({{ i.material_set.labels|map("title")|join('/') }})
+    {% endif %}</a>
+{% endmacro %}
+
+{% macro itemamount(i) %}
+  {% if i.amount == 0 %}
+    <i>destroyed</i>
+  {% else %}
+    {% if i.amount_hint %}
+      <a class="hint" title="{{ i.amount_hint }}">{{ i.amount }}x</a>
+    {% else %}
+      {{ i.amount }}x
+    {% endif %}
+
+    {{ item(i) }}
+  {% endif %}
+{% endmacro %}
+
+{% macro workshop(w) %}
+  <a href="{{ base }}workshop/{{ w.id }}.html">{{ w.translation|title }}</a>
+{% endmacro %}
+
+{% macro craftlist(crafts, show_workshop=true) %}
+  <table class="crafts">
+    <tr>
+      <th>Output</th>
+      <th>Components</th>
+      {% if show_workshop %}<th>Workshop</th>{% endif %}
+      <th>Time</th>
+      <th>Skill</th>
+    </tr>
+
+    {% for craft in crafts %}
+      <tr {% if craft.components|length == 1 %}class="single"{% endif %}>
+        <td>{{ itemamount(craft) }}</td>
+        <td>
+          {% for component in craft.components %}
+            <div>{{ itemamount(component) }}</div>
+          {% endfor %}
+        </td>
+        {% if show_workshop %}
+          <td>
+            {% for w in craft.workshops %}
+              <div>{{ workshop(w) }}</div>
+            {% endfor %}
+          </td>
+        {% endif %}
+        <td class="number">{{ craft.time }}</td>
+        <td>{{ craft.skill|title }}</td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endmacro %}
+
+{% macro constrlist(constructions) %}
+  <table class="constructions">
+    <tr>
+      <th>Category</th>
+      <th>Construction</th>
+      <th>Components</th>
+    </tr>
+
+    {% for cat in constructions %}
+      {% for construction in cat.constructions %}
+        <tr>
+          {% if loop.index == 1 %}
+            <th rowspan="{{ loop.length }}">{{ cat.category }}</th>
+          {% endif %}
+
+          <td>
+            {% if construction.sprite %}
+              {{ macros.sprite(construction.sprite, matset=construction.material_set.id) }}
+            {% endif %}
+            {{ construction.translation|title }}</td>
+          <td>
+            {% for component in construction.components %}
+              <div>{{ macros.itemamount(component) }}</div>
+            {% endfor %}
+          </td>
+        </tr>
+      {% endfor %}
+    {% endfor %}
+  </table>
+{% endmacro %}
+
+{% macro nav_table(only_section=None, class="nav", custom_data=None, custom_path=None) %}
+  <table class="{{ class }}">
+    {% if not custom_data %}
+      {% set data = navtable %}
+    {% else %}
+      {% set only_section = "custom" %}
+      {% set data = [{"label":"custom", "path": custom_path, "categories": custom_data}] %}
+    {% endif %}
+
+    {% for section in data %}
+      {% if not only_section or only_section == section.label %}
+        {% if not only_section %}
+          <tr>
+            <th colspan="3" class="section" data-collapse="{{ section.label }}">{{ section.label }}</th>
+          </tr>
+        {% endif %}
+
+        {% for category in section.categories %}
+          {% for group in category.groups %}
+            <tr {% if not only_section %}data-collapse-group="{{ section.label }}"{% endif %}>
+              {% if loop.index == 1 %}
+                <th class="category" rowspan="{{ loop.length }}">
+                  {{ category.translation|title }}
+                </th>
+              {% endif %}
+
+              {% if not group.hide %}
+                <th class="group">
+                  {{ group.translation|title }}
+                </th>
+              {% endif %}
+
+              <td colspan="{% if group.hide %}2{% else %}1{% endif %}">
+                {% for item in group['items'] %}
+                  <span class="entry">
+                    {% if item.sprite %}
+                      {{ sprite(item.sprite) }}
+                    {% endif %}
+                    <a href="{{ base }}{{ section.path }}/{{ item.id }}.html">{{ item.translation|title }}</a>
+
+                    {% if not loop.last %}
+                      &bull;
+                    {% endif %}
+                  </span>
+                {% endfor %}
+              </td>
+            </tr>
+          {% endfor %}
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
+  </table>
+{% endmacro %}

--- a/docs/lib/themes/default/navtable.html.j2
+++ b/docs/lib/themes/default/navtable.html.j2
@@ -1,0 +1,2 @@
+{% import "macros.html.j2" as macros with context %}
+{{ macros.nav_table() }}

--- a/docs/lib/themes/default/plants.html.j2
+++ b/docs/lib/themes/default/plants.html.j2
@@ -1,0 +1,71 @@
+{% extends "base.html.j2" %}
+{% import "macros.html.j2" as macros with context %}
+
+{% block title %}
+  All Plants - {{ super() }}
+{% endblock %}
+
+{% block content %}
+  <h2>All Plants</h2>
+
+  {% for type in plants %}
+    <h3>{{ type.type }}s</h3>
+
+    <table class="plants">
+      <tr>
+        <th rowspan="2">{{ type.type }}</th>
+        <th colspan="3">Seasons</th>
+        <th colspan="2">Harvesting</th>
+      </tr>
+      <tr>
+        <th>Grows</th>
+        <th>Dies</th>
+        <th>Loses fruit</th>
+        <th>Yield</th>
+        <th>Result</th>
+      </tr>
+
+      {% for plant in type.plants %}
+        <tr>
+          <td>
+            {% if plant.sprite %}
+              {{ macros.sprite(plant.sprite, background=type.floor) }}
+            {% endif %}
+            {{ plant.id|title }}
+          </td>
+          <td class="seasons">
+            {% for season in plant.growseason %}
+              <div>{{ season }}</div>
+            {% endfor %}
+          </td>
+          <td class="seasons">
+            {% for season in plant.killseason %}
+            <div>{{ season }}</div>
+            {% endfor %}
+          </td>
+          <td class="seasons">
+            {% for season in plant.loseseason %}
+              <div>{{ season }}</div>
+            {% endfor %}
+          </td>
+          <td>
+            {% for produce in plant.harvestproduces %}
+              <div>{{ macros.itemamount(produce) }}</div>
+            {% endfor %}
+          </td>
+          <td>
+            <i>
+              {% if plant.harvestaction == 'Destroy' %}
+                Destroy plant
+              {% elif plant.harvestaction == 'StateOneBack' %}
+                Reduce growth stage
+              {% elif plant.harvestaction == 'ReduceFruitCount' %}
+                Reduce fruit count
+              {% endif %}
+            </i>
+          </td>
+        </tr>
+      {% endfor %}
+    </table>
+  {% endfor %}
+{% endblock %}

--- a/docs/lib/themes/default/sprites.css.j2
+++ b/docs/lib/themes/default/sprites.css.j2
@@ -60,8 +60,3 @@
     {% endfor %}
   }
 {% endfor %}
-
-/* FIXME find out why this specific sprite does not have correct offsets */
-.s-constr-BlockStairs .layer:nth-child(2) {
-  top: -4px !important;
-}

--- a/docs/lib/themes/default/sprites.css.j2
+++ b/docs/lib/themes/default/sprites.css.j2
@@ -1,0 +1,94 @@
+.sprite {
+  width: 32px;
+  height: 32px;
+  display: inline-block;
+  vertical-align: bottom;
+  position: relative;
+  image-rendering: crisp-edges;
+  image-rendering: pixelated;
+}
+
+.layers {
+  position: absolute;
+}
+
+.layer,
+.bg {
+  display: block;
+  position: absolute;
+  width: 32px;
+  height: 32px;
+}
+
+.bg {
+  height: 20px;
+}
+
+.zoomed {
+  width: 64px;
+  height: 64px;
+}
+
+.zoomed .bg,
+.zoomed .layers {
+  transform: translate(-50%, -50%) scale(2, 2) translate(50%, 50%);
+}
+
+.bg-plain {
+  background-image: url(terrain.png);
+  background-position: -32px 0;
+}
+
+.bg-stone {
+  background-image: url(terrain.png);
+  background-position: -128px -64px;
+  filter: url(tints.svg#Marble);
+}
+
+.bg-grass {
+  background-image: url(seasonalgrass.png);
+  background-position: -160px -20px;
+}
+
+.bg-farm {
+  background-image: url(terrain.png);
+  background-position: -256px -64px;
+}
+
+.bg-wood {
+  background-image: url(terrain.png);
+  background-position: -64px -64px;
+  filter: url(tints.svg#Pine);
+}
+
+{% for anim in sprite_anims %}
+  @keyframes {{ anim.id() }} {
+    {% for frame in anim.frames %}
+      {{ (100 * loop.index0 / loop.length) | round(2) }}% {
+        {% for prop, value in frame.items() %}
+          {{ prop }}: {{ value }};
+        {% endfor %}
+      }
+    {% endfor %}
+  }
+{% endfor %}
+
+{% for rule in sprite_rules %}
+  {% for selector in rule.selectors|sort %}
+    {{ selector }}{% if not loop.last %},{% endif %}
+  {% endfor %}
+  {
+    {% for prop, value in rule.props.items() %}
+      {% if prop == "animation" %}
+        animation: {{ rule.props["animation-name"].id() }} {{ value }};
+      {% elif prop != "animation-name" %}
+        {{ prop }}: {{ value }};
+      {% endif %}
+    {% endfor %}
+  }
+{% endfor %}
+
+/* FIXME find out why this specific sprite does not have correct offsets */
+.s-constr-BlockStairs .layer:nth-child(2) {
+  top: -4px !important;
+}

--- a/docs/lib/themes/default/sprites.css.j2
+++ b/docs/lib/themes/default/sprites.css.j2
@@ -34,33 +34,6 @@
   transform: translate(-50%, -50%) scale(2, 2) translate(50%, 50%);
 }
 
-.bg-plain {
-  background-image: url(terrain.png);
-  background-position: -32px 0;
-}
-
-.bg-stone {
-  background-image: url(terrain.png);
-  background-position: -128px -64px;
-  filter: url(tints.svg#Marble);
-}
-
-.bg-grass {
-  background-image: url(seasonalgrass.png);
-  background-position: -160px -20px;
-}
-
-.bg-farm {
-  background-image: url(terrain.png);
-  background-position: -256px -64px;
-}
-
-.bg-wood {
-  background-image: url(terrain.png);
-  background-position: -64px -64px;
-  filter: url(tints.svg#Pine);
-}
-
 {% for anim in sprite_anims %}
   @keyframes {{ anim.id() }} {
     {% for frame in anim.frames %}

--- a/docs/lib/themes/default/sprites.py
+++ b/docs/lib/themes/default/sprites.py
@@ -72,6 +72,8 @@ def sprite_style(alt, common={}):
 
     if alt.effect == "Rot90":
         props["transform"] = "rotate(-90deg)"
+    elif alt.effect == "FlipHorizontal":
+        props["transform"] = "rotateY(180deg)"
 
     return props
 
@@ -100,8 +102,16 @@ def common_style(common):
     return props
 
 
-def generate_sprite_styles(sprites):
+def generate_sprite_styles(sprites, backgrounds):
     """Generate style rules and keyframes, and deduplicate them"""
+
+    for bg in backgrounds:
+        if "material" in bg:
+            alt = bg["base"].alternative(tint="Material").tinted(bg["material"])
+        else:
+            alt = bg["base"].alternative()
+        StyleRule.get([f".bg-{bg['id']}"], sprite_style(alt))
+
     for sprite in sprites:
         for matset in sprite["material_sets"]:
             for layer in matset["layers"]:

--- a/docs/lib/themes/default/sprites.py
+++ b/docs/lib/themes/default/sprites.py
@@ -1,0 +1,136 @@
+class Animation:
+    anims = []
+
+    @classmethod
+    def get(cls, id, frames):
+        for anim in cls.anims:
+            if anim.has_frames(frames):
+                anim.ids.append(id)
+                return anim
+        anim = cls(id, frames)
+        cls.anims.append(anim)
+        return anim
+
+    def has_frames(self, frames):
+        return frames == self.frames
+
+    def __init__(self, id, frames):
+        self.ids = [id]
+        self.frames = frames
+
+    def id(self):
+        if len(self.ids) > 1:
+            return f"anim_{Animation.anims.index(self)}"
+        else:
+            return self.ids[0]
+
+
+class StyleRule:
+    rules = []
+
+    @classmethod
+    def get(cls, selectors, props):
+        for rule in cls.rules:
+            if rule.has_props(props):
+                rule.selectors |= set(selectors)
+                return rule
+        rule = cls(selectors, props)
+        cls.rules.append(rule)
+        return rule
+
+    def __init__(self, selectors, props={}):
+        self.selectors = set(selectors)
+        self.props = props
+
+    def has_props(self, props):
+        return props == self.props
+
+
+def sprite_style(alt, common={}):
+    props = {}
+
+    if "tilesheet" not in common:
+        props["background-image"] = f"url({alt.tilesheet})"
+
+    if "rectx" not in common or "recty" not in common:
+        props["background-position"] = f"-{alt.rect['x']}px -{alt.rect['y']}px"
+
+    if "rectw" not in common and alt.rect["w"] != 32:
+        props["width"] = f"{alt.rect['w']}px"
+
+    if "recth" not in common and alt.rect["h"] != 32:
+        props["height"] = f"{alt.rect['h']}px"
+
+    if "ox" not in common and alt.ox != 0:
+        props["left"] = f"{alt.ox}px"
+
+    if "oy" not in common and alt.oy != 0:
+        props["top"] = f"{alt.oy}px"
+
+    if alt.tint == "Material" and alt.material:
+        props["filter"] = f"url(tints.svg#{alt.material})"
+
+    if alt.effect == "Rot90":
+        props["transform"] = "rotate(-90deg)"
+
+    return props
+
+
+def common_style(common):
+    props = {}
+
+    if "tilesheet" in common:
+        props["background-image"] = f"url({common['tilesheet']})"
+
+    if "rectx" in common and "recty" in common:
+        props["background-position"] = f"-{common['rectx']}px -{common['recty']}px"
+
+    if "rectw" in common and common["rectw"] != 32:
+        props["width"] = f"{common['rectw']}px"
+
+    if "recth" in common and common["recth"] != 32:
+        props["height"] = f"{common['recth']}px"
+
+    if "ox" in common and common["ox"] != 0:
+        props["left"] = f"{common['ox']}px"
+
+    if "oy" in common and common["oy"] != 0:
+        props["top"] = f"{common['oy']}px"
+
+    return props
+
+
+def generate_sprite_styles(sprites):
+    """Generate style rules and keyframes, and deduplicate them"""
+    for sprite in sprites:
+        for matset in sprite["material_sets"]:
+            for layer in matset["layers"]:
+                alternatives = layer.unique()
+                alt_count = len(alternatives)
+
+                layer_number = matset["layers"].index(layer) + 1
+                layer_selectors = [
+                    f".s-{sprite['id']}.m-{name} .layer:nth-child({layer_number})" for name in matset["names"]
+                ]
+
+                if alt_count > 1:
+                    common = layer.common()
+                    anim = Animation.get(
+                        f"{sprite['id']}-{matset['id']}-{layer_number}",
+                        [sprite_style(alt, common) for alt in alternatives],
+                    )
+
+                    if len(list(filter(lambda a: not a.animation, alternatives))) == 0:
+                        # Only animation frames, make animation faster
+                        duration = alt_count / 4
+                    else:
+                        duration = alt_count
+
+                    StyleRule.get(
+                        layer_selectors,
+                        {"animation": f"{duration}s infinite step-end", "animation-name": anim, **common_style(common)},
+                    )
+                elif alt_count == 1:
+                    StyleRule.get(layer_selectors, sprite_style(alternatives[0]))
+
+    return (Animation.anims, StyleRule.rules)

--- a/docs/lib/themes/default/theme.py
+++ b/docs/lib/themes/default/theme.py
@@ -1,0 +1,188 @@
+from datetime import datetime
+import os
+import shutil
+from jinja2 import Environment, FileSystemLoader
+
+from ...util import DOCDIR, log, sort_translations, format_css
+from .sprites import generate_sprite_styles
+
+THEME_PATH = os.path.dirname(__file__)
+ASSET_PATH = os.path.join(THEME_PATH, "assets")
+CONTENT_PATH = os.path.realpath(os.path.join(DOCDIR, "..", "content"))
+
+
+class DefaultTheme:
+    content_assets = ["icon.png"]
+    assets = []
+
+    def __init__(self):
+        self.assets = os.listdir(ASSET_PATH)
+        self.env = Environment(loader=FileSystemLoader(THEME_PATH))
+
+    def render(self, store, output, build_id):
+        # Setup directories
+        shutil.rmtree(output, ignore_errors=True)
+
+        for subdir in ["assets", "workshop", "item"]:
+            os.makedirs(os.path.join(output, subdir))
+
+        log("Gathering data")
+
+        categories = store.categories()
+        items = store.items()
+        food = store.food()
+        drinks = store.drinks()
+        plants = store.plants()
+        tints = store.tints()
+        workshops = store.workshops()
+        constructions = store.constructions()
+
+        sprites = store.sprites()
+        tilesheets = set([v["tilesheet"] for sprite in sprites for v in sprite["basesprites"].values()])
+
+        (sprite_anims, sprite_rules) = generate_sprite_styles(sprites)
+
+        # Setup navigation table
+        navtable = [
+            {"label": "Items", "categories": categories, "path": "item"},
+            {
+                "label": "Workshops",
+                "categories": sort_translations(
+                    [
+                        {
+                            "translation": g,
+                            "groups": [{"hide": True, "items": list(filter(lambda w: w["tab"] == g, workshops))}],
+                        }
+                        for g in set(map(lambda w: w["tab"], workshops))
+                    ]
+                ),
+                "path": "workshop",
+            },
+        ]
+
+        # Setup search index
+        search_index = [
+            *[
+                {
+                    "label": i["translation"],
+                    "href": f"item/{i['id']}.html",
+                    "type": "item",
+                    "kw": (
+                        f"{i['id']} {i['translation']} "
+                        f"{i['category']['id']} {i['category']['translation']} "
+                        f"{i['group']['id']} {i['group']['translation']}"
+                    ),
+                }
+                for i in items
+            ],
+            *[
+                {
+                    "label": w["translation"],
+                    "href": f"workshop/{w['id']}.html",
+                    "type": "workshop",
+                    "kw": f"{w['id']} {w['translation']}",
+                }
+                for w in workshops
+            ],
+        ]
+
+        global_context = {
+            "navtable": navtable,
+            "index": search_index,
+            "sprites": sprites,
+            "build": {"id": build_id, "date": datetime.utcnow().isoformat(" ", timespec="minutes")},
+        }
+
+        log("Rendering")
+
+        # Prerender navtable
+        navtable_rendered_root = self.env.get_template("navtable.html.j2").render(**global_context)
+        navtable_rendered_nest = self.env.get_template("navtable.html.j2").render(base="../", **global_context)
+
+        # Generate sprites css
+        with open(os.path.join(output, "assets", "sprites.css"), mode="w") as f:
+            f.write(
+                format_css(
+                    self.env.get_template("sprites.css.j2").render(
+                        tints=tints, sprites=sprites, sprite_anims=sprite_anims, sprite_rules=sprite_rules
+                    )
+                )
+            )
+
+        # Generate tint filters
+        with open(os.path.join(output, "assets", "tints.svg"), mode="w") as f:
+            f.write(self.env.get_template("tints.svg.j2").render(tints=tints))
+
+        # Generate item index
+        with open(os.path.join(output, "items.html"), mode="w") as f:
+            f.write(
+                self.env.get_template("items.html.j2").render(
+                    base="", navtable_rendered=navtable_rendered_root, **global_context
+                )
+            )
+
+        # Generate item pages
+        for item in items:
+            with open(os.path.join(output, "item", f"{item['id']}.html"), mode="w") as f:
+                f.write(
+                    self.env.get_template("item.html.j2").render(
+                        item=item, base="../", navtable_rendered=navtable_rendered_nest, **global_context
+                    )
+                )
+
+        # Generate food index
+        with open(os.path.join(output, "food.html"), mode="w") as f:
+            f.write(
+                self.env.get_template("food.html.j2").render(
+                    base="", navtable_rendered=navtable_rendered_root, food=food, drinks=drinks, **global_context
+                )
+            )
+
+        # Generate plant index
+        with open(os.path.join(output, "plants.html"), mode="w") as f:
+            f.write(
+                self.env.get_template("plants.html.j2").render(
+                    base="", navtable_rendered=navtable_rendered_root, plants=plants, **global_context
+                )
+            )
+
+        # Generate workshop index
+        with open(os.path.join(output, "workshops.html"), mode="w") as f:
+            f.write(
+                self.env.get_template("workshops.html.j2").render(
+                    base="", navtable_rendered=navtable_rendered_root, **global_context
+                )
+            )
+
+        # Generate workshop pages
+        for workshop in workshops:
+            with open(os.path.join(output, "workshop", f"{workshop['id']}.html"), mode="w") as f:
+                f.write(
+                    self.env.get_template("workshop.html.j2").render(
+                        workshop=workshop, base="../", navtable_rendered=navtable_rendered_nest, **global_context
+                    )
+                )
+
+        # Generate construction index
+        with open(os.path.join(output, "constructions.html"), mode="w") as f:
+            f.write(
+                self.env.get_template("constructions.html.j2").render(
+                    base="", navtable_rendered=navtable_rendered_root, constructions=constructions, **global_context
+                )
+            )
+
+        # Generate index
+        with open(os.path.join(output, "index.html"), mode="w") as f:
+            f.write(
+                self.env.get_template("index.html.j2").render(
+                    base="", navtable_rendered=navtable_rendered_root, **global_context
+                )
+            )
+
+        # Copy assets
+        for asset in self.content_assets:
+            shutil.copy(os.path.join(CONTENT_PATH, asset), os.path.join(output, "assets", asset))
+        for asset in self.assets:
+            shutil.copy(os.path.join(ASSET_PATH, asset), os.path.join(output, "assets", asset))
+        for asset in set(["terrain.png", "seasonalgrass.png"]) | tilesheets:
+            shutil.copy(os.path.join(CONTENT_PATH, "tilesheet", asset), os.path.join(output, "assets", asset))

--- a/docs/lib/themes/default/theme.py
+++ b/docs/lib/themes/default/theme.py
@@ -3,6 +3,7 @@ import os
 import shutil
 from jinja2 import Environment, FileSystemLoader
 
+from ...sprite import BaseSprite
 from ...util import DOCDIR, log, sort_translations, format_css
 from .sprites import generate_sprite_styles
 
@@ -14,6 +15,13 @@ CONTENT_PATH = os.path.realpath(os.path.join(DOCDIR, "..", "content"))
 class DefaultTheme:
     content_assets = ["icon.png"]
     assets = []
+    backgrounds = [
+        {"id": "plain", "base": BaseSprite("SolidSelectionFloor")},
+        {"id": "farm", "base": BaseSprite("TilledSoil"), "material": "Dirt"},
+        {"id": "stone", "base": BaseSprite("BlockStoneFloor"), "material": "Marble"},
+        {"id": "grass", "base": BaseSprite("Grass_1_5")},
+        {"id": "wood", "base": BaseSprite("LogFloor"), "material": "Pine"},
+    ]
 
     def __init__(self):
         self.assets = os.listdir(ASSET_PATH)
@@ -36,11 +44,13 @@ class DefaultTheme:
         tints = store.tints()
         workshops = store.workshops()
         constructions = store.constructions()
-
         sprites = store.sprites()
-        tilesheets = set([v["tilesheet"] for sprite in sprites for v in sprite["basesprites"].values()])
 
-        (sprite_anims, sprite_rules) = generate_sprite_styles(sprites)
+        tilesheets = set([v["tilesheet"] for sprite in sprites for v in sprite["basesprites"].values()]) | set(
+            [bg["base"].tilesheet for bg in self.backgrounds]
+        )
+
+        (sprite_anims, sprite_rules) = generate_sprite_styles(sprites, self.backgrounds)
 
         # Setup navigation table
         navtable = [
@@ -184,5 +194,5 @@ class DefaultTheme:
             shutil.copy(os.path.join(CONTENT_PATH, asset), os.path.join(output, "assets", asset))
         for asset in self.assets:
             shutil.copy(os.path.join(ASSET_PATH, asset), os.path.join(output, "assets", asset))
-        for asset in set(["terrain.png", "seasonalgrass.png"]) | tilesheets:
+        for asset in tilesheets:
             shutil.copy(os.path.join(CONTENT_PATH, "tilesheet", asset), os.path.join(output, "assets", asset))

--- a/docs/lib/themes/default/tints.svg.j2
+++ b/docs/lib/themes/default/tints.svg.j2
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  {% for tint in tints %}
+    <filter id="{{ tint.id }}" color-interpolation-filters="sRGB" filterUnits="objectBoundingBox" x="0%" y="0%" width="100%" height="100%">
+      <feColorMatrix
+        values="{{ tint.r / 255 }} 0 0 0 0
+                0 {{ tint.g / 255 }} 0 0 0
+                0 0 {{ tint.b / 255 }} 0 0
+                0 0 0 {{ tint.a / 255 }} 0" />
+    </filter>
+  {% endfor %}
+</svg>

--- a/docs/lib/themes/default/workshop.html.j2
+++ b/docs/lib/themes/default/workshop.html.j2
@@ -1,0 +1,44 @@
+{% extends "base.html.j2" %}
+{% import "macros.html.j2" as macros with context %}
+
+{% block title %}
+  {{ workshop.translation|title }} - {{ super() }}
+{% endblock %}
+
+{% block content %}
+  <h2>
+    <span class="type">{{ workshop.tab|title }} workshop</span>
+    {{ workshop.translation|title }}
+  </h2>
+
+  <h3>Building components</h3>
+
+  <table class="workshop-components">
+    <tr>
+      <th>Item</th>
+      <th>Requires workshop</th>
+    </tr>
+    {% for item in workshop.components %}
+      <tr>
+        <td>
+          {{ macros.itemamount(item) }}
+        </td>
+        <td>
+          {% if item.workshops|length %}
+            {% for w in item.workshops %}
+              <div>{{ macros.workshop(w) }}</div>
+            {% endfor %}
+          {% else %}
+            <i>(raw material)</i>
+          {% endif %}
+        </td>
+      </tr>
+    {% endfor %}
+  </table>
+
+  {% if workshop.crafts|length %}
+    <h3>Used to craft</h3>
+
+    {{ macros.craftlist(workshop.crafts, show_workshop=false) }}
+  {% endif %}
+{% endblock %}

--- a/docs/lib/themes/default/workshops.html.j2
+++ b/docs/lib/themes/default/workshops.html.j2
@@ -1,0 +1,12 @@
+{% extends "base.html.j2" %}
+{% import "macros.html.j2" as macros with context %}
+
+{% block title %}
+  All Workshops - {{ super() }}
+{% endblock %}
+
+{% block content %}
+  <h2>All Workshops</h2>
+
+  {{ macros.nav_table(only_section="Workshops", class="") }}
+{% endblock %}

--- a/docs/lib/util.py
+++ b/docs/lib/util.py
@@ -14,7 +14,7 @@ def sprite_rect(rect):
 
 def sprite_offset(offset):
     (x, y) = (0, 0) if empty(offset) else map(int, offset.replace(",", "").strip().split(" "))
-    return {"x": x, "y": y, "z": 0}
+    return {"x": x, "y": y}
 
 
 def sprite_offset3d(offset):

--- a/docs/lib/util.py
+++ b/docs/lib/util.py
@@ -1,0 +1,69 @@
+import os
+
+DOCDIR = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
+
+
+def empty(value):
+    return value is None or value == ""
+
+
+def sprite_rect(rect):
+    (x, y, w, h) = map(int, rect.split(" "))
+    return {"x": x, "y": y, "w": w, "h": h}
+
+
+def sprite_offset(offset):
+    (x, y) = (0, 0) if empty(offset) else map(int, offset.replace(",", "").strip().split(" "))
+    return {"x": x, "y": y, "z": 0}
+
+
+def sprite_offset3d(offset):
+    (x, y, z) = (0, 0, 0) if empty(offset) else map(int, offset.strip().split(" "))
+    return {"x": x, "y": y, "z": z}
+
+
+def sprite_layers(sprite):
+    return sprite
+
+
+def sort_translations(lst):
+    return sorted(lst, key=lambda item: item["translation"] if "translation" in item else item["id"])
+
+
+def total_amount(chance):
+    return sum(map(lambda x: 1 if float(x) == 0 else float(x), chance.split("|")))
+
+
+def amount_hint(chance):
+    chances = list(map(float, chance.split("|")))
+    guaranteed = len(list(filter(lambda x: x == 0, chances)))
+    optional = filter(lambda x: x > 0, chances)
+
+    if guaranteed == len(chances):
+        return None
+
+    return ", ".join([f"{guaranteed} guaranteed", *map(lambda c: f"{int(c*100)}% chance to get 1 more", optional)])
+
+
+def format_css(css):
+    """Trivial formatter to make reading output easier"""
+    lines = []
+    level = 0
+
+    for line in css.splitlines():
+        line = line.strip()
+        if len(line):
+            if "{" in line:
+                lines.append(f"{'  ' * level}{line}")
+                level = level + 1
+            elif "}" in line:
+                level = level - 1
+                lines.append(f"{'  ' * level}{line}")
+            else:
+                lines.append(f"{'  ' * level}{line}")
+
+    return "\n".join(lines)
+
+
+def log(msg, prefix="* "):
+    print(f"{prefix}{msg}")


### PR DESCRIPTION
This adds a documentation generation system built off of python and jinja2. Docs are generated from data in the db. Generated docs are static, with minimal js for search and collapsing stuff, that should fallback gracefully should visitors not have js enabled. Sprite rendering uses only css (a LOT of css).

Generating the docs requires python 3.9 and pipenv, and requires having the tilesheets copied in the repository.

This PR includes a new github workflow to generate docs when pushing tags (also on demand) and publish them on github pages. A `DOCS_DOMAIN` repo secret can be set to enable a custom domain, if it ever becomes a thing.

The generator is written to make switching data sources possible, if the game moves to eg. JSON. We should also be able to add different themes later if we want to use it to generate docs to display in-game; generating either HTML or XAML should not be an issue. We could also write a theme to output data to prefill a wiki at some point.

Adding i18n should also not be very complex.

A preview of rendered docs is available at https://ingnomia.njoyard.fr.

Also, I'm not quite sure how to handle licensing around Gnomoria assets, this probably needs to be figured out.
