### PR TITLE
Noesisgui init

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Note! Building on Mac is currently not possible. Certain features in the rendere
 #### All Platforms ####
 * OpenGL 4.3 - Mac is not a supported compilation platform since it has deprecated OpenGL
 * Qt 5.14.1 or newer
-* [Noesis Gui](https://www.noesisengine.com/developers/downloads.php) 3.0.12\
+* [Noesis Gui](https://www.noesisengine.com/developers/downloads.php) 3.1\
   For using Noesis in a local development build, you need to get a [trial license](https://www.noesisengine.com/trial/).
 * [Steam SDK](https://partner.steamgames.com/doc/sdk)
 * [SFML 2.5.1](https://www.sfml-dev.org/download/sfml/2.5.1/)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -614,7 +614,8 @@ void MainWindow::noesisInit()
 	Noesis::GUI::DisableInspector();
 
 	// Noesis initialization. This must be the first step before using any NoesisGUI functionality
-	Noesis::GUI::Init( licenseName, licenseKey );
+	Noesis::GUI::SetLicense( licenseName, licenseKey );
+	Noesis::GUI::Init();
 
 	installResourceProviders();
 


### PR DESCRIPTION
The NoesisGUI Init function and license info was changed slightly between v. 3.0 and 3.1:
`GUI::Init no longer receives license information, it must be passed to GUI::SetLicense.`

This PR assumes that requiring 3.1 is the desired solution. I didn't see an elegant way to support both.

There are [a few other breaking changes with the 3.1 update](https://www.noesisengine.com/docs/Gui.Core.Changelog.html), but as far as I can tell none of them impact this project.