### PR TITLE
Refactor getting game folder path

### DIFF
--- a/src/base/config.cpp
+++ b/src/base/config.cpp
@@ -32,7 +32,7 @@ Config::Config()
 	IO::createFolders();
 
 	//check if Ingnomia folder in /Documents/My Games exist
-	QString folder = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/";
+	QString folder = IO::getDataFolder();
 	bool ok        = true;
 	QJsonDocument jd;
 

--- a/src/base/crashhandler.cpp
+++ b/src/base/crashhandler.cpp
@@ -1,6 +1,7 @@
 #include "crashhandler.h"
 
 #include "../version.h"
+#include "io.h"
 
 #if defined( PROJECT_VERSION) && defined( BUILD_ID )
 #define BUILD_VERSION PROJECT_VERSION "-" BUILD_ID
@@ -29,7 +30,7 @@ void setupCrashHandler()
 	mpSender->setGuardByteBufferSize( 20 * 1024 * 1024 );
 
 	// Include main log file
-	QString logFile = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/log.txt";
+	QString logFile = IO::getDataFolder() + "/log.txt";
 	mpSender->sendAdditionalFile( logFile.replace( '/', '\\' ).toStdWString().c_str() );
 }
 #else

--- a/src/base/io.cpp
+++ b/src/base/io.cpp
@@ -82,7 +82,7 @@ bool IO::saveCompatible( QString folder )
 
 bool IO::saveGameExists()
 {
-	QString folder = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/save/";
+	QString folder = getDataFolder() + "/save/";
 
 	if ( !QDir( folder ).exists() || QDir( folder ).isEmpty() )
 	{
@@ -93,7 +93,7 @@ bool IO::saveGameExists()
 
 bool IO::saveConfig()
 {
-	QString folder = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/settings/";
+	QString folder = getDataFolder() + "/settings/";
 
 	QVariantMap cm   = Global::cfg->object();
 	QJsonDocument jd = QJsonDocument::fromVariant( cm );
@@ -103,22 +103,27 @@ bool IO::saveConfig()
 	return true;
 }
 
+QString IO::getDataFolder()
+{
+#ifdef _WIN32
+	return QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia";
+#else
+	// corresponds to ~/.local/share/<APPNAME> on Linux
+	return QStandardPaths::writableLocation( QStandardPaths::AppDataLocation ) + "/Ingnomia";
+#endif
+}
+
 QString IO::getTempFolder()
 {
-	return QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/tmp/";
+	return getDataFolder() + "/tmp/";
 }
 
 bool IO::createFolders()
 {
-	QString folder = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/";
+	QString folder = getDataFolder() + "/";
 	if ( !QDir( folder ).exists() )
 	{
-		QDir().mkdir( folder );
-	}
-	folder += "Ingnomia/";
-	if ( !QDir( folder ).exists() )
-	{
-		QDir().mkdir( folder );
+		QDir().mkpath( folder );
 	}
 	QString modFolder = folder + "mods/";
 	if ( !QDir( modFolder ).exists() )
@@ -167,7 +172,7 @@ bool IO::createFolders()
 	}
 	*/
 
-	folder = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/save/";
+	folder = getDataFolder() + "/save/";
 
 	return QDir( folder ).exists();
 }
@@ -184,7 +189,7 @@ QString IO::save( bool autosave )
 	QElapsedTimer timer;
 	timer.start();
 
-	QString folder = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/save/";
+	QString folder = getDataFolder() + "/save/";
 
 	if ( !QDir( folder ).exists() )
 	{

--- a/src/base/io.h
+++ b/src/base/io.h
@@ -32,6 +32,7 @@ public:
 	IO( Game* g, QObject* parent );
 	~IO();
 
+	static QString getDataFolder();
 	static bool createFolders();
 	static bool saveConfig();
 	static bool loadOriginalConfig( QJsonDocument& jd );

--- a/src/game/gamemanager.cpp
+++ b/src/game/gamemanager.cpp
@@ -146,7 +146,7 @@ void GameManager::setUpNewGame()
 void GameManager::continueLastGame()
 {
 	//get last save
-	QString folder = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/save/";
+	QString folder = IO::getDataFolder() + "/save/";
 
 	QDir dir( folder );
 	dir.setFilter( QDir::Dirs | QDir::NoDotAndDotDot );
@@ -155,7 +155,7 @@ void GameManager::continueLastGame()
 	{
 		auto kingdomDir = dir.entryList().first();
 
-		folder = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/save/" + kingdomDir + "/";
+		folder = IO::getDataFolder() + "/save/" + kingdomDir + "/";
 		QDir dir2( folder );
 		dir2.setFilter( QDir::Dirs | QDir::NoDotAndDotDot );
 		dir2.setSorting( QDir::Time );

--- a/src/game/gnomemanager.cpp
+++ b/src/game/gnomemanager.cpp
@@ -402,18 +402,18 @@ void GnomeManager::saveProfessions()
 	}
 
 	QJsonDocument sd = QJsonDocument::fromVariant( pl );
-	IO::saveFile( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/settings/profs.json", sd );
+	IO::saveFile( IO::getDataFolder() + "/settings/profs.json", sd );
 }
 
 void GnomeManager::loadProfessions()
 {
 	QJsonDocument sd;
-	if ( !IO::loadFile( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/settings/profs.json", sd ) )
+	if ( !IO::loadFile( IO::getDataFolder() + "/settings/profs.json", sd ) )
 	{
 		// if it doesn't exist get from /content/JSON
 		if ( IO::loadFile( Global::cfg->get( "dataPath" ).toString() + "/JSON/profs.json", sd ) )
 		{
-			IO::saveFile( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/settings/profs.json", sd );
+			IO::saveFile( IO::getDataFolder() + "/settings/profs.json", sd );
 		}
 		else
 		{

--- a/src/game/militarymanager.cpp
+++ b/src/game/militarymanager.cpp
@@ -201,7 +201,7 @@ void MilitaryManager::init()
 	{
 		//load from file
 		QJsonDocument jd;
-		IO::loadFile( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/settings/military.json", jd );
+		IO::loadFile( IO::getDataFolder() + "/settings/military.json", jd );
 		QVariantMap vm = jd.toVariant().toMap();
 		if ( vm.contains( "Roles" ) )
 		{
@@ -244,7 +244,7 @@ void MilitaryManager::save()
 	auto vm = serialize();
 	vm.remove( "Squads" );
 	QJsonObject jo = QJsonObject::fromVariantMap( vm );
-	IO::saveFile( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/" + "settings/military.json", jo );
+	IO::saveFile( IO::getDataFolder() + "/settings/military.json", jo );
 }
 
 QVariantMap MilitaryManager::serialize()

--- a/src/game/newgamesettings.cpp
+++ b/src/game/newgamesettings.cpp
@@ -94,7 +94,7 @@ void NewGameSettings::save()
 	embarkMap.insert( "startingItems", startItems );
 
 	QJsonDocument sd = QJsonDocument::fromVariant( embarkMap );
-	IO::saveFile( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/" + "settings/newgame.json", sd );
+	IO::saveFile( IO::getDataFolder() + "/settings/newgame.json", sd );
 
 	savePreset( startItems );
 }
@@ -152,12 +152,12 @@ void NewGameSettings::loadEmbarkMap()
 	m_checkableItems.clear();
 
 	QJsonDocument sd;
-	if ( !IO::loadFile( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/" + "settings/newgame.json", sd ) )
+	if ( !IO::loadFile( IO::getDataFolder() + "/settings/newgame.json", sd ) )
 	{
 		// if it doesn't exist get from /content/JSON
 		if ( IO::loadFile( Global::cfg->get( "dataPath" ).toString() + "/JSON/newgame.json", sd ) )
 		{
-			IO::saveFile( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/" + "settings/newgame.json", sd );
+			IO::saveFile( IO::getDataFolder() + "/settings/newgame.json", sd );
 		}
 		else
 		{
@@ -510,7 +510,7 @@ void NewGameSettings::loadPresets()
 		m_standardPresets = sd.toVariant().toList();
 	}
 
-	ok = IO::loadFile( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/settings/userpresets.json", sd );
+	ok = IO::loadFile( IO::getDataFolder() + "/settings/userpresets.json", sd );
 	if ( ok )
 	{
 		m_userPresets.clear();
@@ -529,7 +529,7 @@ void NewGameSettings::saveUserPresets()
 		up.append( pm );
 	}
 	QJsonDocument sd = QJsonDocument::fromVariant( up );
-	IO::saveFile( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/settings/userpresets.json", sd );
+	IO::saveFile( IO::getDataFolder() + "/settings/userpresets.json", sd );
 }
 
 void NewGameSettings::setPreset( QString name )

--- a/src/gui/aggregatorloadgame.cpp
+++ b/src/gui/aggregatorloadgame.cpp
@@ -42,7 +42,7 @@ AggregatorLoadGame::~AggregatorLoadGame()
 
 void AggregatorLoadGame::onRequestKingdoms()
 {
-	QString sfolder = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/save";
+	QString sfolder = IO::getDataFolder() + "/save";
 
 	m_kingdomList.clear();
 

--- a/src/gui/keybindings.cpp
+++ b/src/gui/keybindings.cpp
@@ -104,7 +104,7 @@ KeyBindings::~KeyBindings()
 
 void KeyBindings::update()
 {
-	QString folder = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/settings/";
+	QString folder = IO::getDataFolder() + "/settings/";
 	QJsonDocument jd;
 	IO::loadFile( folder + "keybindings.json", jd );
 	qDebug() << "Load key bindings...";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 */
 #include "base/config.h"
 #include "base/db.h"
+#include "base/io.h"
 #include "base/crashhandler.h"
 #include "base/global.h"
 
@@ -47,12 +48,12 @@ bool verbose     = false;
 
 void clearLog()
 {
-	QString folder   = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/";
+	QString folder   = IO::getDataFolder();
 	bool ok          = true;
 	QString fileName = "log.txt";
 	if ( QDir( folder ).exists() )
 	{
-		fileName = folder + fileName;
+		fileName = folder + "/" + fileName;
 	}
 
 	QFile file( fileName );
@@ -62,12 +63,12 @@ void clearLog()
 
 QPointer<QFile> openLog()
 {
-	QString folder   = QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/My Games/Ingnomia/";
+	QString folder   = IO::getDataFolder();
 	bool ok          = true;
 	QString fileName = "log.txt";
 	if ( QDir( folder ).exists() )
 	{
-		fileName = folder + fileName;
+		fileName = folder + "/" + fileName;
 	}
 
 	QPointer<QFile> outFile(new QFile( fileName ));


### PR DESCRIPTION
Put the setting of the main path on one place and change it to a proper dot directory on Linux (where it should be) as there might even be no Documents folder present.

On Windows, it could be probably also stored inside AppDataLocation; for compatibility reasons, I left that as it was.