### PR TITLE
Remove Qt (part 1 of ...)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -138,6 +138,13 @@ jobs:
     - name: Create Build Environment
       run: cmake -E make_directory build
 
+    - name: Use GCC-10 on Linux
+      if: (!startsWith(matrix.config.os, 'windows'))
+      shell: bash
+      run: |
+        echo "CC=gcc-10" >> $GITHUB_ENV
+        echo "CXX=g++-10" >> $GITHUB_ENV
+
     - name: Configure CMake
       working-directory: ${{github.workspace}}/build
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
 cmake_minimum_required(VERSION 3.16.0)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # Disable release-builds without debug info
 set(CMAKE_CONFIGURATION_TYPES Debug RelWithDebInfo CACHE STRING INTERNAL FORCE)
 
@@ -41,7 +45,7 @@ add_executable(${PROJECT_NAME})
 # C++ version
 set_target_properties(${PROJECT_NAME}
 	PROPERTIES
-		CXX_STANDARD 17
+		CXX_STANDARD 20
 		AUTOMOC ON
 		INTERPROCEDURAL_OPTIMIZATION ON
 		INSTALL_RPATH "$ORIGIN"

--- a/src/base/PathFinderThread.h
+++ b/src/base/PathFinderThread.h
@@ -23,6 +23,7 @@
 #include <functional>
 #include <vector>
 #include <unordered_set>
+#include <unordered_map>
 
 class World;
 

--- a/src/base/config.cpp
+++ b/src/base/config.cpp
@@ -25,6 +25,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QStandardPaths>
+#include <QCoreApplication>
 
 Config::Config()
 {

--- a/src/base/db.cpp
+++ b/src/base/db.cpp
@@ -27,6 +27,7 @@
 #include <QSqlQuery>
 #include <QSqlRecord>
 #include <QThread>
+#include <QFile>
 
 QMutex DB::m_mutex;
 int DB::accessCounter = 0;

--- a/src/base/db.h
+++ b/src/base/db.h
@@ -22,6 +22,7 @@
 #include "../base/dbstructs.h"
 #include "../base/position.h"
 
+#include <QPointer>
 #include <QList>
 #include <QMutex>
 #include <QSqlDatabase>

--- a/src/base/dbhelper.cpp
+++ b/src/base/dbhelper.cpp
@@ -17,6 +17,7 @@
 */
 #include "dbhelper.h"
 
+#include <QDebug>
 #include "../base/db.h"
 #include "../base/gamestate.h"
 

--- a/src/base/filter.cpp
+++ b/src/base/filter.cpp
@@ -34,6 +34,7 @@
 */
 #include "filter.h"
 
+#include <QElapsedTimer>
 #include "../base/db.h"
 #include "../base/global.h"
 #include "../game/game.h"

--- a/src/base/filter.cpp
+++ b/src/base/filter.cpp
@@ -180,7 +180,7 @@ bool Filter::getCheckState( QString category, QString group, QString item, QStri
 	return m_categories[category].getCheckState( group, item, material );
 }
 
-const QSet<QPair<QString, QString>>& Filter::getActive()
+const std::set<QPair<QString, QString>>& Filter::getActive()
 {
 	if ( m_activeDirty )
 	{
@@ -208,7 +208,7 @@ const QSet<QPair<QString, QString>>& Filter::getActive()
 	return m_active;
 }
 
-QSet<QString> Filter::getActiveSimple()
+std::set<QString> Filter::getActiveSimple()
 {
 	if ( m_activeSimpleDirty )
 	{

--- a/src/base/filter.h
+++ b/src/base/filter.h
@@ -20,6 +20,7 @@
 #include <QDebug>
 #include <QMap>
 #include <QString>
+#include <set>
 
 class FilterItem
 {
@@ -100,8 +101,8 @@ public:
 
 	bool getCheckState( QString category, QString group, QString item, QString material );
 
-	const QSet<QPair<QString, QString>>& getActive();
-	QSet<QString> getActiveSimple();
+	const std::set<QPair<QString, QString>>& getActive();
+	std::set<QString> getActiveSimple();
 	void setActiveSimple( QString val );
 
 	void update();
@@ -111,6 +112,6 @@ private:
 
 	bool m_activeDirty       = true;
 	bool m_activeSimpleDirty = true;
-	QSet<QPair<QString, QString>> m_active;
-	QSet<QString> m_activeSimple;
+	std::set<QPair<QString, QString>> m_active;
+	std::set<QString> m_activeSimple;
 };

--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -50,7 +50,7 @@ QVariantMap Global::copiedStockpileSettings;
 
 QMap<QString, QVariantMap> Global::m_windowParams;
 
-QMap<QString, QSet<QString>> Global::allowedInContainer;
+QMap<QString, std::set<QString>> Global::allowedInContainer;
 
 QHash<Qt::Key, Noesis::Key> Global::keyConvertMap;
 
@@ -76,7 +76,7 @@ unsigned int Global::dirtUID = 0;
 QMap<QString, CreaturePart> Global::creaturePartLookUp;
 QMap<CreaturePart, QString> Global::creaturePartToString;
 
-QSet<QString> Global::craftable;
+std::set<QString> Global::craftable;
 
 void Global::reset()
 {

--- a/src/base/global.h
+++ b/src/base/global.h
@@ -24,7 +24,7 @@
 
 #include <QDomElement>
 #include <QMap>
-#include <QSet>
+#include <set>
 #include <QString>
 #include <QVariant>
 #include <QtGlobal>
@@ -70,7 +70,7 @@ public:
 	static bool debugOpenGL;
 	static bool debugSound;
 
-	static QMap<QString, QSet<QString>> allowedInContainer;
+	static QMap<QString, std::set<QString>> allowedInContainer;
 
 	static QStringList needIDs;
 	static QMap<QString, float> needDecays;
@@ -86,7 +86,7 @@ public:
 
 	static Noesis::Key keyConvert( Qt::Key key );
 
-	static QSet<QString> craftable;
+	static std::set<QString> craftable;
 
 	static EventConnector* eventConnector;
 	static Util* util;

--- a/src/base/io.cpp
+++ b/src/base/io.cpp
@@ -47,6 +47,7 @@
 #include "../gfx/spritefactory.h"
 #include "../gui/strings.h"
 
+#include <QCoreApplication>
 #include <QDebug>
 #include <QDir>
 #include <QDirIterator>

--- a/src/base/io.h
+++ b/src/base/io.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <QObject>
+#include <QPointer>
 
 class Game;
 

--- a/src/base/lightmap.cpp
+++ b/src/base/lightmap.cpp
@@ -44,7 +44,7 @@ void LightMap::init()
 	m_dimZ = Global::dimZ;
 }
 
-void LightMap::addLight( QSet<unsigned int>& updateList, std::vector<Tile>& world, unsigned int id, Position pos, int intensity )
+void LightMap::addLight( std::set<unsigned int>& updateList, std::vector<Tile>& world, unsigned int id, Position pos, int intensity )
 {
 	Light light;
 	light.id        = id;
@@ -52,13 +52,13 @@ void LightMap::addLight( QSet<unsigned int>& updateList, std::vector<Tile>& worl
 	light.intensity = intensity;
 
 	QQueue<QPair<Position, int>> wq;
-	QSet<unsigned int> visited;
+	std::set<unsigned int> visited;
 	wq.enqueue( QPair<Position, int>( pos, 0 ) );
 	int decay = Global::cfg->get( "lightDecay" ).toInt();
 
 	int range = intensity / decay;
 
-	visited.reserve( range * range * range );
+	// visited.reserve( range * range * range );    // Not in std::set
 
 	while ( !wq.empty() )
 	{
@@ -152,7 +152,7 @@ unsigned char LightMap::calcIntensity( unsigned int posID )
 	}
 }
 
-void LightMap::removeLight( QSet<unsigned int>& updateList, std::vector<Tile>& world, unsigned int id )
+void LightMap::removeLight( std::set<unsigned int>& updateList, std::vector<Tile>& world, unsigned int id )
 {
 	if ( m_lights.contains( id ) )
 	{
@@ -170,7 +170,7 @@ void LightMap::removeLight( QSet<unsigned int>& updateList, std::vector<Tile>& w
 	}
 }
 
-void LightMap::updateLight( QSet<unsigned int>& updateList, std::vector<Tile>& world, Position pos )
+void LightMap::updateLight( std::set<unsigned int>& updateList, std::vector<Tile>& world, Position pos )
 {
 	unsigned int posID = pos.toInt();
 	if ( m_lightMap.contains( posID ) )

--- a/src/base/lightmap.h
+++ b/src/base/lightmap.h
@@ -38,9 +38,9 @@ public:
 
 	void init();
 
-	void addLight( QSet<unsigned int>& updateList, std::vector<Tile>& world, unsigned int id, Position pos, int intensity );
-	void removeLight( QSet<unsigned int>& updateList, std::vector<Tile>& world, unsigned int id );
-	void updateLight( QSet<unsigned int>& updateList, std::vector<Tile>& world, Position pos );
+	void addLight( std::set<unsigned int>& updateList, std::vector<Tile>& world, unsigned int id, Position pos, int intensity );
+	void removeLight( std::set<unsigned int>& updateList, std::vector<Tile>& world, unsigned int id );
+	void updateLight( std::set<unsigned int>& updateList, std::vector<Tile>& world, Position pos );
 
 private:
 	QMap<unsigned int, QMap<unsigned int, unsigned char>> m_lightMap;

--- a/src/base/octree.cpp
+++ b/src/base/octree.cpp
@@ -71,8 +71,8 @@ bool Octree::removeItem( int x, int y, int z, unsigned int item )
 {
 	if ( m_isLeaf )
 	{
-		m_items.remove( item );
-		return m_items.isEmpty();
+		m_items.erase( item );
+		return m_items.empty();
 	}
 	else
 	{
@@ -105,7 +105,7 @@ QList<unsigned int> Octree::query( int x, int y, int z, int limit ) const
 {
 	if ( m_isLeaf )
 	{
-		return m_items.values();
+		return {m_items.begin(), m_items.end()};
 	}
 	else
 	{

--- a/src/base/octree.h
+++ b/src/base/octree.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <QList>
-#include <QSet>
+#include <set>
 
 #include <functional>
 
@@ -47,5 +47,5 @@ private:
 	const bool m_isLeaf;
 
 	Octree* m_children[8] = { 0 };
-	QSet<unsigned int> m_items;
+	std::set<unsigned int> m_items;
 };

--- a/src/base/pathfinder.h
+++ b/src/base/pathfinder.h
@@ -21,7 +21,6 @@
 
 #include <QMutex>
 #include <QQueue>
-#include <QSet>
 #include <QThreadPool>
 #include <QVector>
 #include <optional>

--- a/src/base/region.cpp
+++ b/src/base/region.cpp
@@ -17,12 +17,6 @@
 */
 #include "region.h"
 
-#include <unordered_map>
-#include "../base/global.h"
-#include "../game/world.h"
-
-#include <QDebug>
-
 Region::Region( unsigned int id ) :
 	m_id( id )
 {
@@ -42,7 +36,7 @@ void Region::addConnectionTo( unsigned int toRegion, const Position& pos )
 }
 void Region::removeConnectionFrom( unsigned int toRegion, const Position& pos )
 {
-	m_connectionsFrom[toRegion].remove( pos.toString() );
+	m_connectionsFrom[toRegion].erase( pos.toString() );
 	if ( m_connectionsFrom[toRegion].empty() )
 	{
 		m_connectionsFrom.remove( toRegion );
@@ -50,7 +44,7 @@ void Region::removeConnectionFrom( unsigned int toRegion, const Position& pos )
 }
 void Region::removeConnectionTo( unsigned int toRegion, const Position& pos )
 {
-	m_connectionsTo[toRegion].remove( pos.toString() );
+	m_connectionsTo[toRegion].erase( pos.toString() );
 	if ( m_connectionsTo[toRegion].empty() )
 	{
 		m_connectionsTo.remove( toRegion );
@@ -67,7 +61,7 @@ void Region::addConnectionTo( unsigned int toRegion, QString pos )
 }
 void Region::removeConnectionFrom( unsigned int toRegion, QString pos )
 {
-	m_connectionsFrom[toRegion].remove( pos );
+	m_connectionsFrom[toRegion].erase( pos );
 	if ( m_connectionsFrom[toRegion].empty() )
 	{
 		m_connectionsFrom.remove( toRegion );
@@ -75,7 +69,7 @@ void Region::removeConnectionFrom( unsigned int toRegion, QString pos )
 }
 void Region::removeConnectionTo( unsigned int toRegion, QString pos )
 {
-	m_connectionsTo[toRegion].remove( pos );
+	m_connectionsTo[toRegion].erase( pos );
 	if ( m_connectionsTo[toRegion].empty() )
 	{
 		m_connectionsTo.remove( toRegion );

--- a/src/base/region.cpp
+++ b/src/base/region.cpp
@@ -17,6 +17,7 @@
 */
 #include "region.h"
 
+#include <unordered_map>
 #include "../base/global.h"
 #include "../game/world.h"
 

--- a/src/base/region.h
+++ b/src/base/region.h
@@ -20,7 +20,7 @@
 #include "../base/position.h"
 
 #include <QMap>
-#include <QSet>
+#include <set>
 
 class Region
 {
@@ -50,16 +50,16 @@ public:
 	void removeAllConnectionsFrom( unsigned int id );
 	void removeAllConnectionsTo( unsigned int id );
 
-	QMap<unsigned int, QSet<QString>> connectionSetFrom()
+	QMap<unsigned int, std::set<QString>> connectionSetFrom()
 	{
 		return m_connectionsFrom;
 	};
-	QMap<unsigned int, QSet<QString>> connectionSetTo()
+	QMap<unsigned int, std::set<QString>> connectionSetTo()
 	{
 		return m_connectionsTo;
 	}
 
-	QSet<QString> connectionsToRegion( unsigned int region )
+	std::set<QString> connectionsToRegion( unsigned int region )
 	{
 		return m_connectionsTo.value( region );
 	}
@@ -79,6 +79,6 @@ public:
 
 private:
 	unsigned int m_id = 0;
-	QMap<unsigned int, QSet<QString>> m_connectionsFrom;
-	QMap<unsigned int, QSet<QString>> m_connectionsTo;
+	QMap<unsigned int, std::set<QString>> m_connectionsFrom;
+	QMap<unsigned int, std::set<QString>> m_connectionsTo;
 };

--- a/src/base/regionmap.cpp
+++ b/src/base/regionmap.cpp
@@ -740,7 +740,7 @@ bool RegionMap::checkConnectedRegions( unsigned int start, unsigned int goal )
 	}
 	//qDebug() << "check connection between " << start << goal;
 	QQueue<unsigned int> floodQueue;
-	QSet<unsigned int> visited;
+	std::set<unsigned int> visited;
 	for ( auto con : region( start ).connectionsTo() )
 	{
 		floodQueue.enqueue( con );

--- a/src/base/regionmap.h
+++ b/src/base/regionmap.h
@@ -22,6 +22,7 @@
 #include <QSet>
 
 #include <vector>
+#include <unordered_map>
 
 struct Tile;
 class Region;

--- a/src/base/regionmap.h
+++ b/src/base/regionmap.h
@@ -19,8 +19,6 @@
 
 #include "../base/position.h"
 
-#include <QSet>
-
 #include <vector>
 #include <unordered_map>
 

--- a/src/base/selection.cpp
+++ b/src/base/selection.cpp
@@ -797,7 +797,7 @@ void Selection::onSecondClick( bool shift, bool ctrl )
 	{
 		if ( m_action == "Deconstruct" )
 		{
-			QSet<unsigned int> workshops;
+			std::set<unsigned int> workshops;
 
 			QList<QPair<Position, bool>> newSelection;
 

--- a/src/base/selection.h
+++ b/src/base/selection.h
@@ -19,6 +19,8 @@
 
 #include "../base/position.h"
 
+#include <QElapsedTimer>
+#include <QPointer>
 #include <QColor>
 #include <QList>
 #include <QPair>

--- a/src/base/util.cpp
+++ b/src/base/util.cpp
@@ -206,7 +206,7 @@ int Util::toolLevel( QString materialSID )
 	return 0;
 }
 
-QSet<QString> Util::itemsAllowedInContainer( unsigned int containerID )
+std::set<QString> Util::itemsAllowedInContainer( unsigned int containerID )
 {
 	return Global::allowedInContainer.value( g->inv()->itemSID( containerID ) );
 }

--- a/src/base/util.h
+++ b/src/base/util.h
@@ -57,7 +57,7 @@ public:
 	int toolLevel( unsigned int itemUID );
 	int toolLevel( QString materialSID );
 
-	QSet<QString> itemsAllowedInContainer( unsigned int container );
+	std::set<QString> itemsAllowedInContainer( unsigned int container );
 	bool itemAllowedInContainer( unsigned int item, unsigned int container );
 	void initAllowedInContainer();
 	QString carryContainerForItem( QString itemSID );

--- a/src/base/util.h
+++ b/src/base/util.h
@@ -19,6 +19,7 @@
 
 #include "../base/position.h"
 
+#include <QPointer>
 #include <QGridLayout>
 #include <QLayoutItem>
 #include <QPixmap>

--- a/src/game/anatomy.h
+++ b/src/game/anatomy.h
@@ -19,7 +19,6 @@
 
 #include "../base/enums.h"
 
-#include <QSet>
 #include <QString>
 #include <QVariantMap>
 

--- a/src/game/animal.h
+++ b/src/game/animal.h
@@ -19,6 +19,7 @@
 
 #include "creature.h"
 
+#include <QPointer>
 #include <QString>
 #include <QtGlobal>
 

--- a/src/game/creature.h
+++ b/src/game/creature.h
@@ -23,6 +23,7 @@
 #include "../game/anatomy.h"
 #include "object.h"
 
+#include <QPointer>
 #include <QPixmap>
 
 class QPainter;

--- a/src/game/creatureEquipment.cpp
+++ b/src/game/creatureEquipment.cpp
@@ -17,6 +17,8 @@
 */
 #include "creature.h"
 
+#include <QDebug>
+
 QVariantMap EquipmentItem::serialize()
 {
 	QVariantMap out;

--- a/src/game/eventmanager.h
+++ b/src/game/eventmanager.h
@@ -24,6 +24,7 @@
 
 #include <QMap>
 #include <QObject>
+#include <QPointer>
 #include <QVariantMap>
 
 class Game;

--- a/src/game/fluidmanager.h
+++ b/src/game/fluidmanager.h
@@ -21,7 +21,6 @@
 #include "../base/position.h"
 #include "../game/job.h"
 
-#include <QSet>
 #include <QPointer>
 
 class Game;

--- a/src/game/fluidmanager.h
+++ b/src/game/fluidmanager.h
@@ -22,6 +22,7 @@
 #include "../game/job.h"
 
 #include <QSet>
+#include <QPointer>
 
 class Game;
 

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -20,7 +20,9 @@
 
 #include "../base/enums.h"
 
+#include <QPointer>
 #include <QObject>
+#include <QElapsedTimer>
 
 class Config;
 class NewGameSettings;

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -23,6 +23,7 @@
 #include <QPointer>
 #include <QObject>
 #include <QElapsedTimer>
+#include <set>
 
 class Config;
 class NewGameSettings;
@@ -174,7 +175,7 @@ signals:
 	void signalEvent( unsigned int id, QString title, QString msg, bool pause, bool yesno );
 	void signalStartAutoSave();
 	void signalEndAutoSave();
-	void signalUpdateTileInfo( QSet<unsigned int> changeSet );
+	void signalUpdateTileInfo( std::set<unsigned int> changeSet );
 	void signalUpdateStockpile();
 };
 

--- a/src/game/gamemanager.cpp
+++ b/src/game/gamemanager.cpp
@@ -280,7 +280,6 @@ void GameManager::postCreationInit()
 	connect( m_eventConnector, &EventConnector::signalCameraPosition, m_eventConnector->aggregatorSound(), &AggregatorSound::onCameraPosition, Qt::QueuedConnection );
 
 
-	qRegisterMetaType<QSet<unsigned int>>();
 	connect( m_game, &Game::signalUpdateTileInfo,  m_eventConnector->aggregatorTileInfo(), &AggregatorTileInfo::onUpdateAnyTileInfo );
 	connect( m_game, &Game::signalUpdateStockpile, m_eventConnector->aggregatorStockpile(), &AggregatorStockpile::onUpdateAfterTick );
 	connect( m_game, &Game::signalUpdateTileInfo,  m_eventConnector->aggregatorRenderer(), &AggregatorRenderer::onUpdateAnyTileInfo );

--- a/src/game/gamemanager.cpp
+++ b/src/game/gamemanager.cpp
@@ -66,6 +66,7 @@
 #include "../gui/aggregatorselection.h"
 #include "../gui/aggregatorsound.h"
 
+#include <QPointer>
 #include <QDateTime>
 #include <QDebug>
 #include <QDir>

--- a/src/game/gamemanager.h
+++ b/src/game/gamemanager.h
@@ -19,6 +19,7 @@
 
 #include "../base/enums.h"
 
+#include <QPointer>
 #include <QObject>
 #include <QString>
 #include <QThread>

--- a/src/game/gnomeactions.cpp
+++ b/src/game/gnomeactions.cpp
@@ -970,7 +970,7 @@ BT_RESULT Gnome::actionClaimItems( bool halt )
 
 			if ( materialID == "any" && !restrictions.empty() )
 			{
-				QSet<QString> matTypes;
+				std::set<QString> matTypes;
 				for ( auto type : restrictions )
 				{
 					matTypes.insert( type );

--- a/src/game/inventory.cpp
+++ b/src/game/inventory.cpp
@@ -398,7 +398,7 @@ void Inventory::destroyObject( unsigned int id )
 			unsigned int tileID = item->getPos().toInt();
 			if ( m_positionHash.contains( tileID ) )
 			{
-				m_positionHash[tileID].remove( id );
+				m_positionHash[tileID].erase( id );
 				if ( m_positionHash[tileID].empty() )
 				{
 					m_positionHash.remove( tileID );
@@ -439,7 +439,7 @@ unsigned int Inventory::getFirstObjectAtPosition( const Position& pos )
 	{
 		if ( !m_positionHash[pos.toInt()].empty() )
 		{
-			for ( auto itemUID : m_positionHash[pos.toInt()].values() )
+			for ( auto itemUID : m_positionHash[pos.toInt()] )
 			{
 				if ( !isConstructed( itemUID ) && !isInContainer( itemUID ) )
 				{
@@ -497,7 +497,7 @@ unsigned int Inventory::getClosestItem( const Position& pos, bool allowInStockpi
 	return 0;
 }
 
-unsigned int Inventory::getClosestItem2( const Position& pos, bool allowInStockpile, QString itemSID, QSet<QString> materialTypes )
+unsigned int Inventory::getClosestItem2( const Position& pos, bool allowInStockpile, QString itemSID, std::set<QString> materialTypes )
 {
 	for ( auto matType : materialTypes )
 	{
@@ -574,7 +574,7 @@ unsigned int Inventory::getItemAtPos( const Position& pos, bool allowInStockpile
 				}
 				else
 				{
-					m_positionHash[pos.toInt()].remove( itemID );
+					m_positionHash[pos.toInt()].erase( itemID );
 				}
 			}
 		}
@@ -594,7 +594,7 @@ unsigned int Inventory::getItemAtPos( const Position& pos, bool allowInStockpile
 				}
 				else
 				{
-					m_positionHash[pos.toInt()].remove( itemID );
+					m_positionHash[pos.toInt()].erase( itemID );
 				}
 			}
 		}
@@ -654,7 +654,7 @@ QList<unsigned int> Inventory::getClosestItems( const Position& pos, bool allowI
 	return out;
 }
 
-QList<unsigned int> Inventory::getClosestItemsForStockpile( unsigned int stockpileID, Position& pos, bool allowInStockpile, QSet<QPair<QString, QString>> filter )
+QList<unsigned int> Inventory::getClosestItemsForStockpile( unsigned int stockpileID, Position& pos, bool allowInStockpile, std::set<QPair<QString, QString>> filter )
 {
 	QString itemSID;
 	QString materialSID;
@@ -818,7 +818,7 @@ unsigned int Inventory::pickUpItem( unsigned int id, unsigned int creatureID )
 		const Position& pos = item->getPos();
 		if ( m_positionHash.contains( pos.toInt() ) )
 		{
-			m_positionHash[pos.toInt()].remove( id );
+			m_positionHash[pos.toInt()].erase( id );
 		}
 		if ( m_positionHash[pos.toInt()].empty() )
 		{
@@ -841,7 +841,7 @@ unsigned int Inventory::pickUpItem( unsigned int id, unsigned int creatureID )
 
 					Octree* ot2 = octree( inItemSID, inMatSID );
 					ot2->removeItem( pos.x, pos.y, pos.z, inItemID );
-					m_positionHash[pos.toInt()].remove( inItemID );
+					m_positionHash[pos.toInt()].erase( inItemID );
 				}
 			}
 		}

--- a/src/game/inventory.cpp
+++ b/src/game/inventory.cpp
@@ -1599,14 +1599,14 @@ bool Inventory::requireSame( unsigned int id )
 	return false;
 }
 
-const QSet<unsigned int>& Inventory::itemsInContainer( unsigned int containerID )
+const std::set<unsigned int>& Inventory::itemsInContainer( unsigned int containerID )
 {
 	auto container = getItem( containerID );
 	if ( container )
 	{
 		return container->containedItems();
 	}
-	static const QSet<unsigned int> nullopt;
+	static const std::set<unsigned int> nullopt;
 	return nullopt;
 }
 

--- a/src/game/inventory.h
+++ b/src/game/inventory.h
@@ -28,7 +28,7 @@
 #include <QMap>
 #include <QString>
 
-typedef QSet<unsigned int> PositionEntry;
+typedef std::set<unsigned int> PositionEntry;
 typedef QHash<unsigned int, PositionEntry> PositionHash;
 
 class ItemHistory;
@@ -63,7 +63,7 @@ public:
 
 	unsigned int getClosestItem( const Position& pos, bool allowInStockpile, QString itemID, QString materialID = "any" );
 	//from construction dialog with materialTypes selected any
-	unsigned int getClosestItem2( const Position& pos, bool allowInStockpile, QString itemID, QSet<QString> materialTypes );
+	unsigned int getClosestItem2( const Position& pos, bool allowInStockpile, QString itemID, std::set<QString> materialTypes );
 	unsigned int getItemAtPos( const Position& pos, bool allowInStockpile, QString itemID, QString materialID = "any" );
 
 	QList<unsigned int> getClosestItems( const Position& pos, bool allowInStockpile, QList<QPair<QString, QString>> filter, int count );
@@ -73,7 +73,7 @@ public:
 	*/
 	QList<unsigned int> getClosestItems( const Position& pos, bool allowInStockpile, QString itemSID, QString materialSID, int count );
 	bool checkReachableItems( Position pos, bool allowInStockpile, int count, QString itemSID, QString materialSID = "any" );
-	QList<unsigned int> getClosestItemsForStockpile( unsigned int stockpileID, Position& pos, bool allowInStockpile, QSet<QPair<QString, QString>> filter );
+	QList<unsigned int> getClosestItemsForStockpile( unsigned int stockpileID, Position& pos, bool allowInStockpile, std::set<QPair<QString, QString>> filter );
 
 	unsigned int getFoodItem( Position& pos );
 	unsigned int getDrinkItem( Position& pos );

--- a/src/game/inventory.h
+++ b/src/game/inventory.h
@@ -167,7 +167,7 @@ public:
 	void setColor( unsigned int item, QString color );
 	unsigned int color( unsigned int item );
 
-	const QSet<unsigned int>& itemsInContainer( unsigned int container );
+	const std::set<unsigned int>& itemsInContainer( unsigned int container );
 
 	int countItemsAtPos( Position& pos );
 

--- a/src/game/inventory.h
+++ b/src/game/inventory.h
@@ -22,6 +22,7 @@
 #include "../base/priorityqueue.h"
 #include "../game/item.h"
 
+#include <QPointer>
 #include <QHash>
 #include <QList>
 #include <QMap>

--- a/src/game/item.cpp
+++ b/src/game/item.cpp
@@ -272,13 +272,13 @@ bool Item::isContainer() const
 	return false;
 }
 
-const QSet<unsigned int>& Item::containedItems() const
+const std::set<unsigned int>& Item::containedItems() const
 {
 	if ( m_extraData )
 	{
 		return m_extraData->containedItems;
 	}
-	static const QSet<unsigned int> nullopt;
+	static const std::set<unsigned int> nullopt;
 	return nullopt;
 }
 
@@ -506,7 +506,7 @@ bool Item::removeItem( unsigned int itemID )
 {
 	if ( m_extraData )
 	{
-		return m_extraData->containedItems.remove( itemID );
+		return m_extraData->containedItems.erase( itemID );
 	}
 	return false;
 }

--- a/src/game/item.h
+++ b/src/game/item.h
@@ -29,7 +29,7 @@ struct ItemExtraData
 {
 
 	QList<ItemMaterial> components;
-	QSet<unsigned int> containedItems;
+	std::set<unsigned int> containedItems;
 
 	unsigned char nutritionalValue = 0;
 	unsigned char drinkValue       = 0;
@@ -88,7 +88,7 @@ public:
 	unsigned int madeBy() const;
 	void setMadeBy( unsigned int creatureID );
 
-	const QSet<unsigned int>& containedItems() const;
+	const std::set<unsigned int>& containedItems() const;
 	unsigned char capacity() const;
 	bool requireSame() const;
 

--- a/src/game/itemhistory.cpp
+++ b/src/game/itemhistory.cpp
@@ -120,7 +120,7 @@ void ItemHistory::deserialize( const QVariantMap& in )
 	for ( auto entry : vlItems )
 	{
 		QString itemSID = entry.toMap().value( "ID" ).toString();
-		QSet<QString> mats;
+		std::set<QString> mats;
 		for ( auto vmat : entry.toMap().value( "Mats" ).toList() )
 		{
 			mats.insert( vmat.toString() );
@@ -286,7 +286,7 @@ void ItemHistory::plusItem( QString itemSID, QString materialSID )
 			matEntry.insert( materialSID, IH_values { 1, 1, 0 } );
 			m_currentDay.dayData.data.insert( itemSID, matEntry );
 		}
-		QSet<QString> mats;
+		std::set<QString> mats;
 		mats.insert( materialSID );
 		m_itemsPresent.insert( itemSID, mats );
 	}
@@ -313,7 +313,7 @@ QMap<QString, QVector<IH_values>> ItemHistory::getHistory( QString itemSID )
 {
 	QMap<QString, QVector<IH_values>> out;
 
-	QSet<QString> mats = m_itemsPresent.value( itemSID );
+	std::set<QString> mats = m_itemsPresent.value( itemSID );
 	out.insert( "all", QVector<IH_values>() );
 	for ( auto mat : mats )
 	{

--- a/src/game/itemhistory.h
+++ b/src/game/itemhistory.h
@@ -19,7 +19,7 @@
 
 #include <QMap>
 #include <QObject>
-#include <QSet>
+#include <set>
 
 struct IH_values
 {
@@ -64,7 +64,7 @@ public:
 		m_startUp = false;
 	}
 
-	QMap<QString, QSet<QString>> allItems()
+	QMap<QString, std::set<QString>> allItems()
 	{
 		return m_itemsPresent;
 	}
@@ -79,7 +79,7 @@ private:
 	QList<IH_day> m_data;
 	IH_day m_currentDay;
 
-	QMap<QString, QSet<QString>> m_itemsPresent;
+	QMap<QString, std::set<QString>> m_itemsPresent;
 
 	bool m_startUp = true;
 };

--- a/src/game/jobmanager.h
+++ b/src/game/jobmanager.h
@@ -27,6 +27,7 @@
 #include <QMap>
 #include <QQueue>
 #include <QString>
+#include <QPointer>
 
 class Game;
 

--- a/src/game/jobmanager.h
+++ b/src/game/jobmanager.h
@@ -49,7 +49,7 @@ private:
 
 	QHash<QString, QStringList> m_jobIDs;
 
-	QSet<QString> m_workshopSkills;
+	std::set<QString> m_workshopSkills;
 
 	int m_startIndex;
 

--- a/src/game/mechanismmanager.h
+++ b/src/game/mechanismmanager.h
@@ -81,8 +81,8 @@ struct MechanismNetwork
 	unsigned int produce = 0;
 	unsigned int consume = 0;
 
-	QSet<unsigned int> producers;
-	QSet<unsigned int> consumers;
+	std::set<unsigned int> producers;
+	std::set<unsigned int> consumers;
 };
 
 class MechanismManager : public QObject

--- a/src/game/mechanismmanager.h
+++ b/src/game/mechanismmanager.h
@@ -18,6 +18,7 @@
 #pragma once
 
 
+#include <QPointer>
 #include "../base/position.h"
 #include "../base/tile.h"
 #include "../game/job.h"

--- a/src/game/militarymanager.cpp
+++ b/src/game/militarymanager.cpp
@@ -151,7 +151,7 @@ Squad::Squad( QList<QString> tps, const QVariantMap& in ) :
 
 	if( in.contains( "Priorities" ) )
 	{
-		QSet<QString> typeSet;
+		std::set<QString> typeSet;
 		auto vl = in.value( "Priorities" ).toList();
 		for( auto vEntry : vl )
 		{

--- a/src/game/militarymanager.h
+++ b/src/game/militarymanager.h
@@ -22,7 +22,6 @@
 
 #include <QObject>
 #include <QRandomGenerator>
-#include <QSet>
 #include <QVariantMap>
 
 class Game;

--- a/src/game/neighbormanager.h
+++ b/src/game/neighbormanager.h
@@ -20,6 +20,7 @@
 
 #include "../base/position.h"
 
+#include <QPointer>
 #include <QMap>
 #include <QVariantMap>
 

--- a/src/game/newgamesettings.cpp
+++ b/src/game/newgamesettings.cpp
@@ -22,6 +22,7 @@
 #include "../base/io.h"
 #include "../gui/strings.h"
 
+#include <QCoreApplication>
 #include <QDebug>
 #include <QJsonDocument>
 #include <QStandardPaths>

--- a/src/game/pasture.cpp
+++ b/src/game/pasture.cpp
@@ -48,7 +48,8 @@ PastureProperties::PastureProperties( QVariantMap& in )
 	maxTroughCapacity = in.value( "MaxTroughCapacity" ).toInt();
 	troughContent     = in.value( "TroughContent" ).toInt();
 
-	foodSettings = in.value( "Food" ).toStringList().toSet();
+	const auto &listFood = in.value( "Food" ).toStringList();
+	foodSettings = std::set(listFood.begin(), listFood.end());
 
 	animalSize = DB::select( "PastureSize", "Animals", animalType ).toInt();
 }
@@ -71,7 +72,7 @@ void PastureProperties::serialize( QVariantMap& out ) const
 	out.insert( "MaxTroughCapacity", maxTroughCapacity );
 	out.insert( "TroughContent", troughContent );
 
-	out.insert( "Food", QStringList( foodSettings.values() ) );
+	out.insert( "Food", QStringList( foodSettings.begin(), foodSettings.end() ) );
 }
 
 Pasture::Pasture( QList<QPair<Position, bool>> tiles, Game* game ) :
@@ -325,7 +326,7 @@ void Pasture::onTick( quint64 tick, int& count )
 		}
 	}
 	//fill troughs
-	if ( !m_properties.foodSettings.isEmpty() && m_properties.maxTroughCapacity > 0 )
+	if ( !m_properties.foodSettings.empty() && m_properties.maxTroughCapacity > 0 )
 	{
 		if ( m_properties.troughContent < m_properties.maxTroughCapacity - 9 )
 		{
@@ -691,7 +692,7 @@ Position Pasture::findShed()
 	return Position();
 }
 
-QSet<QString>& Pasture::foodSettings()
+std::set<QString>& Pasture::foodSettings()
 {
 	return m_properties.foodSettings;
 }
@@ -703,7 +704,7 @@ void Pasture::addFoodSetting( QString itemSID, QString materialSID )
 
 void Pasture::removeFoodSetting( QString itemSID, QString materialSID )
 {
-	m_properties.foodSettings.remove( itemSID + "_" + materialSID );
+	m_properties.foodSettings.erase( itemSID + "_" + materialSID );
 }
 
 void Pasture::addFood( unsigned int itemID )

--- a/src/game/pasture.h
+++ b/src/game/pasture.h
@@ -61,7 +61,7 @@ struct PastureProperties
 
 	QList<qint8> jobPriorities;
 
-	QSet<QString> foodSettings;
+	std::set<QString> foodSettings;
 
 	void serialize( QVariantMap& out ) const;
 	PastureProperties() {};
@@ -107,7 +107,7 @@ public:
 	Position randomFieldPos();
 	Position findShed();
 
-	QSet<QString>& foodSettings();
+	std::set<QString>& foodSettings();
 	void addFoodSetting( QString itemSID, QString materialSID );
 	void removeFoodSetting( QString itemSID, QString materialSID );
 	void addFood( unsigned int itemID );

--- a/src/game/plant.h
+++ b/src/game/plant.h
@@ -20,6 +20,7 @@
 #include "object.h"
 
 #include <QString>
+#include <QPointer>
 
 class Game;
 

--- a/src/game/roommanager.h
+++ b/src/game/roommanager.h
@@ -21,8 +21,6 @@
 #include "../base/position.h"
 #include "../game/room.h"
 
-#include <QSet>
-
 class Job;
 class Room;
 class Game;

--- a/src/game/soundmanager.h
+++ b/src/game/soundmanager.h
@@ -17,6 +17,7 @@
 */
 #pragma once
 
+#include <QPointer>
 #include "../base/position.h"
 
 struct SoundEffect

--- a/src/game/stockpile.cpp
+++ b/src/game/stockpile.cpp
@@ -241,7 +241,7 @@ bool Stockpile::onTick( quint64 tick )
 		{
 			auto possibleSloits     = freeSlots();
 			const auto activeFilter = m_filter.getActive();
-			QSet<QPair<QString, QString>> effectiveFilter;
+			std::set<QPair<QString, QString>> effectiveFilter;
 			if ( possibleSloits.contains( QPair<QString, QString> { "Any", "Any" } ) )
 			{
 				effectiveFilter = activeFilter;
@@ -270,9 +270,9 @@ bool Stockpile::onTick( quint64 tick )
 	return false;
 }
 
-QSet<QPair<QString, QString>> Stockpile::freeSlots() const
+std::set<QPair<QString, QString>> Stockpile::freeSlots() const
 {
-	QSet<QPair<QString, QString>> freeSlots;
+	std::set<QPair<QString, QString>> freeSlots;
 	for ( auto infi : m_fields )
 	{
 		if ( !infi->isFull )
@@ -313,7 +313,7 @@ QSet<QPair<QString, QString>> Stockpile::freeSlots() const
 
 unsigned int Stockpile::getJob()
 {
-	if ( m_isFull || !m_active || m_filter.getActive().isEmpty() || m_fields.empty() )
+	if ( m_isFull || !m_active || m_filter.getActive().empty() || m_fields.empty() )
 		return 0;
 
 	int itemsChecked = 0;
@@ -354,7 +354,7 @@ unsigned int Stockpile::getJob()
 						unsigned int reservedItemID = *infi->reservedItems.begin();
 						if ( !g->inv()->itemExists( reservedItemID ) || g->inv()->isInJob( reservedItemID ) == 0 )
 						{
-							infi->reservedItems.remove( reservedItemID );
+							infi->reservedItems.erase( reservedItemID );
 						}
 					}
 
@@ -593,7 +593,7 @@ unsigned int Stockpile::createJob( unsigned int itemID, InventoryField* infi )
 
 unsigned int Stockpile::getCleanUpJob()
 {
-	if ( !m_active || m_filter.getActive().isEmpty() )
+	if ( !m_active || m_filter.getActive().empty() )
 		return 0;
 
 	// cleaning up
@@ -720,7 +720,7 @@ bool Stockpile::giveBackJob( unsigned int jobID )
 			Position pos = job->pos();
 			if ( m_fields.contains( pos.toInt() ) )
 			{
-				m_fields[pos.toInt()]->reservedItems.remove( itemID );
+				m_fields[pos.toInt()]->reservedItems.erase( itemID );
 				m_fields[pos.toInt()]->isFull = false;
 				m_isFull                      = false;
 			}
@@ -764,7 +764,7 @@ bool Stockpile::insertItem( Position pos, unsigned int item )
 	if ( m_fields.contains( pos.toInt() ) )
 	{
 		InventoryField* field = m_fields.value( pos.toInt() );
-		field->reservedItems.remove( item );
+		field->reservedItems.erase( item );
 		field->items.insert( item );
 		field->isFull  = false;
 		m_isFull       = false;
@@ -820,7 +820,7 @@ bool Stockpile::removeItem( Position pos, unsigned int item )
 	if ( m_fields.contains( pos.toInt() ) )
 	{
 		InventoryField* field = m_fields[pos.toInt()];
-		if ( field->items.remove( item ) )
+		if ( field->items.erase( item ) )
 		{
 			field->isFull = false;
 			m_isFull      = false;
@@ -882,7 +882,7 @@ void Stockpile::setCheckState( bool state, QString category, QString group, QStr
 	if ( !state )
 	{
 		// unchecked some items, need to expel it from the stockpile
-		QSet<QString> filter = m_filter.getActiveSimple();
+		std::set<QString> filter = m_filter.getActiveSimple();
 
 		for ( auto infi : m_fields )
 		{
@@ -897,7 +897,7 @@ void Stockpile::setCheckState( bool state, QString category, QString group, QStr
 			}
 			for ( auto tr : toRemove )
 			{
-				infi->items.remove( tr );
+				infi->items.erase( tr );
 			}
 		}
 	}

--- a/src/game/stockpile.h
+++ b/src/game/stockpile.h
@@ -39,8 +39,8 @@ struct InventoryField
 	unsigned char capacity   = 1;
 	unsigned char stackSize  = 1;
 	unsigned int containerID = 0;
-	QSet<unsigned int> items;
-	QSet<unsigned int> reservedItems;
+	std::set<unsigned int> items;
+	std::set<unsigned int> reservedItems;
 
 	bool requireSame = false;
 };
@@ -83,7 +83,7 @@ public:
 	// returns true if the possible item list was updated
 	bool onTick( quint64 tick );
 
-	QSet<QPair<QString, QString>> freeSlots() const;
+	std::set<QPair<QString, QString>> freeSlots() const;
 
 	Filter filter()
 	{

--- a/src/game/stockpilemanager.h
+++ b/src/game/stockpilemanager.h
@@ -20,8 +20,6 @@
 #include "../base/position.h"
 #include "../game/stockpile.h"
 
-#include <QSet>
-
 class Job;
 class Stockpile;
 class Inventory;

--- a/src/game/techtree.h
+++ b/src/game/techtree.h
@@ -19,7 +19,7 @@
 
 #include <QMap>
 #include <QObject>
-#include <QSet>
+#include <set>
 
 struct TTNode
 {
@@ -27,8 +27,8 @@ struct TTNode
 	QString itemSID;
 	QString craftID;
 
-	QSet<QString> parents;
-	QSet<QString> childs;
+	std::set<QString> parents;
+	std::set<QString> childs;
 };
 
 class TechTree : public QObject

--- a/src/game/world.cpp
+++ b/src/game/world.cpp
@@ -640,7 +640,7 @@ void World::processGrass()
 	}
 	for ( auto p : toRemove )
 	{
-		m_grassCandidatePositions.remove( p.toInt() );
+		m_grassCandidatePositions.erase( p.toInt() );
 	}
 }
 
@@ -695,7 +695,7 @@ void World::removeGrass( Position pos )
 
 	if ( m_grass.contains( pos.toInt() ) )
 	{
-		m_grass.remove( pos.toInt() );
+		m_grass.erase( pos.toInt() );
 
 		Tile& tile           = getTile( pos );
 		tile.vegetationLevel = 0;
@@ -852,8 +852,8 @@ struct Neighbors
 void World::processWaterFlow()
 {
 	// Batch newly tracked water tiles
-	QSet<unsigned int> newWater;
-	QSet<unsigned int> removedWater;
+	std::set<unsigned int> newWater;
+	std::set<unsigned int> removedWater;
 
 	QVector<unsigned int> drain;
 	QVector<unsigned int> flood;
@@ -1699,10 +1699,10 @@ void World::addToUpdateList( const QVector<unsigned int>& ul )
 	}
 }
 
-void World::addToUpdateList( const QSet<unsigned int>& ul )
+void World::addToUpdateList( const std::set<unsigned int>& ul )
 {
 	QMutexLocker lock( &m_updateMutex );
-	m_updatedTiles += ul;
+	m_updatedTiles.insert(ul.begin(), ul.end());
 }
 
 void World::setDoorLocked( unsigned int tileUID, bool lockGnome, bool lockMonster, bool lockAnimal )
@@ -1752,21 +1752,21 @@ void World::putLight( const unsigned short x, const unsigned short y, const unsi
 
 void World::addLight( unsigned int id, Position pos, int intensity )
 {
-	QSet<unsigned int> ul;
+	std::set<unsigned int> ul;
 	m_lightMap.addLight( ul, m_world, id, pos, intensity );
 	addToUpdateList( ul );
 }
 
 void World::removeLight( unsigned int id )
 {
-	QSet<unsigned int> ul;
+	std::set<unsigned int> ul;
 	m_lightMap.removeLight( ul, m_world, id );
 	addToUpdateList( ul );
 }
 
 void World::moveLight( unsigned int id, Position pos, int intensity )
 {
-	QSet<unsigned int> ul;
+	std::set<unsigned int> ul;
 	m_lightMap.removeLight( ul, m_world, id );
 	m_lightMap.addLight( ul, m_world, id, pos, intensity );
 	addToUpdateList( ul );
@@ -1774,7 +1774,7 @@ void World::moveLight( unsigned int id, Position pos, int intensity )
 
 void World::updateLightsInRange( Position pos )
 {
-	QSet<unsigned int> ul;
+	std::set<unsigned int> ul;
 	m_lightMap.updateLight( ul, m_world, pos );
 	addToUpdateList( ul );
 }

--- a/src/game/world.h
+++ b/src/game/world.h
@@ -27,7 +27,6 @@
 #include <QPointer>
 #include <QMutex>
 #include <QPixmap>
-#include <QSet>
 
 #include <set>
 #include <vector>
@@ -92,14 +91,14 @@ private:
 	QMap<unsigned int, QList<unsigned int>> m_creaturePositions;
 	QMap<unsigned int, QVariantMap> m_wallConstructions;
 	QMap<unsigned int, QVariantMap> m_floorConstructions;
-	QSet<Position> m_grass;
-	QSet<unsigned int> m_grassCandidatePositions;
+	std::set<Position> m_grass;
+	std::set<unsigned int> m_grassCandidatePositions;
 	QMap<unsigned int, QVariantMap> m_jobSprites;
 	std::set<unsigned int> m_water;
 	QList<Position> m_aquifiers;
 	QList<Position> m_deaquifiers;
 
-	QSet<unsigned int> m_updatedTiles;
+	std::set<unsigned int> m_updatedTiles;
 
 	QMap<QString, CONSTRUCTION_ID> m_constructionSID2ENUM;
 	QMap<QString, CONSTR_ITEM_ID> m_constrItemSID2ENUM;
@@ -290,12 +289,12 @@ public:
 	bool noTree( const Position pos, const int xRange, const int yRange );
 	bool noShroom( const Position pos, const int xRange, const int yRange );
 
-	QSet<unsigned int> updatedTiles();
+	std::set<unsigned int> updatedTiles();
 	void addToUpdateList( const unsigned int uID );
 	void addToUpdateList( const Position pos );
 	void addToUpdateList( const unsigned short x, const unsigned short y, const unsigned short z );
 	void addToUpdateList( const QVector<unsigned int>& ul );
-	void addToUpdateList( const QSet<unsigned int>& ul );
+	void addToUpdateList( const std::set<unsigned int>& ul );
 
 	void setDoorLocked( unsigned int tileUID, bool lockGnome, bool lockMonster, bool lockAnimal );
 

--- a/src/game/world.h
+++ b/src/game/world.h
@@ -24,6 +24,7 @@
 #include "../base/regionmap.h"
 #include "../base/tile.h"
 
+#include <QPointer>
 #include <QMutex>
 #include <QPixmap>
 #include <QSet>

--- a/src/game/worldgenerator.cpp
+++ b/src/game/worldgenerator.cpp
@@ -885,6 +885,7 @@ void WorldGenerator::fillFloorMushroomBiome( int zz, QVector<TerrainMaterial>& m
 						tile.wallSpriteUID                                                                = g->sf()->createSprite( mat.wall, { mat.key } )->uID;
 						mat.wallSprite                                                                    = tile.wallSpriteUID;
 						mats[matsinLevel[qMin( m_dimZ - 1, qMax( 0, z - m_heightMap[x + y * m_dimX] ) )]] = mat;
+						// TODO: Is this a bug?
 						g->sf()->createSprite( mat.shortwall, { mat.key } )->uID;
 					}
 					if ( m_fow )
@@ -966,6 +967,7 @@ void WorldGenerator::fillFloor( int z, QVector<TerrainMaterial>& mats, QVector<i
 							tile.wallSpriteUID                                                                = g->sf()->createSprite( mat.wall, { mat.key } )->uID;
 							mat.wallSprite                                                                    = tile.wallSpriteUID;
 							mats[matsinLevel[qMin( m_dimZ - 1, qMax( 0, z - m_heightMap[x + y * m_dimX] ) )]] = mat;
+							// TODO: Is this a bug?
 							g->sf()->createSprite( mat.shortwall, { mat.key } )->uID;
 						}
 						if ( m_fow )

--- a/src/game/worldgenerator.h
+++ b/src/game/worldgenerator.h
@@ -19,6 +19,7 @@
 
 #include "../../3rdparty/fastnoise/FastNoise.h"
 
+#include <QPointer>
 #include <QMap>
 #include <QObject>
 #include <QVector>

--- a/src/game/worldgetters.cpp
+++ b/src/game/worldgetters.cpp
@@ -245,13 +245,13 @@ bool World::noShroom( const Position pos, const int xRange, const int yRange )
 	return true;
 }
 
-QSet<unsigned int> World::updatedTiles()
+std::set<unsigned int> World::updatedTiles()
 {
 	QMutexLocker lock( &m_updateMutex );
-	QSet<unsigned int> ret;
-	ret.swap( m_updatedTiles );
+	std::set<unsigned int> ret;
+	std::swap(ret, m_updatedTiles);
 	// Assume next update batch is going to be similar in size
-	m_updatedTiles.reserve( ret.size() );
+	// m_updatedTiles.reserve( ret.size() );    // Not in std::set
 	return ret;
 }
 

--- a/src/gfx/spritefactory.cpp
+++ b/src/gfx/spritefactory.cpp
@@ -113,7 +113,7 @@ bool SpriteFactory::init()
 			/*
 			if( tilesheet == "default.png" )
 			{
-				QSet<QString>unused;
+				std::set<QString>unused;
 				int count = 0;
 				for( auto r : DB::selectRows( "BaseSprites" ) )
 				{

--- a/src/gui/aggregatorinventory.cpp
+++ b/src/gui/aggregatorinventory.cpp
@@ -338,7 +338,7 @@ void AggregatorInventory::onSetActive( bool active, const GuiWatchedItem& gwi )
 	}
 	else
 	{
-		m_watchedItems.remove( key );
+		m_watchedItems.erase( key );
 		for( int i = 0; i < GameState::watchedItemList.size(); ++i )
 		{
 			auto hwi = GameState::watchedItemList[i];

--- a/src/gui/aggregatorinventory.h
+++ b/src/gui/aggregatorinventory.h
@@ -24,7 +24,7 @@
 #include <QList>
 #include <QHash>
 #include <QMap>
-#include <QSet>
+#include <set>
 
 class Game;
 
@@ -153,7 +153,7 @@ private:
     
     QList<GuiBuildItem> m_buildItems;
 
-    QSet<QString> m_watchedItems;
+    std::set<QString> m_watchedItems;
 
     QMap<BuildSelection, QString> m_buildSelection2String;
     QMap<BuildSelection, BuildItemType> m_buildSelection2buildItem;

--- a/src/gui/aggregatorinventory.h
+++ b/src/gui/aggregatorinventory.h
@@ -19,9 +19,12 @@
 
 #include "../base/enums.h"
 
+#include <QPointer>
 #include <QObject>
 #include <QList>
 #include <QHash>
+#include <QMap>
+#include <QSet>
 
 class Game;
 

--- a/src/gui/aggregatorrenderer.cpp
+++ b/src/gui/aggregatorrenderer.cpp
@@ -261,7 +261,7 @@ void AggregatorRenderer::onAllTileInfo()
 	}
 }
 
-void AggregatorRenderer::onUpdateAnyTileInfo( const QSet<unsigned int>& changeSet )
+void AggregatorRenderer::onUpdateAnyTileInfo( const std::set<unsigned int>& changeSet )
 {
 	if( !g ) return;
 	// Bake tile updates

--- a/src/gui/aggregatorrenderer.h
+++ b/src/gui/aggregatorrenderer.h
@@ -113,7 +113,7 @@ private:
 public slots:
 	void onWorldParametersChanged();
 	void onAllTileInfo();
-	void onUpdateAnyTileInfo( const QSet<unsigned int>& changeSet );
+	void onUpdateAnyTileInfo( const std::set<unsigned int>& changeSet );
 	void onThoughtBubbleUpdate();
 	void onAxleDataUpdate();
 	void onCenterCamera( const Position& location );

--- a/src/gui/aggregatorrenderer.h
+++ b/src/gui/aggregatorrenderer.h
@@ -22,6 +22,7 @@
 
 #include <QObject>
 #include <QVector>
+#include <QPointer>
 
 class Game;
 

--- a/src/gui/aggregatorsettings.cpp
+++ b/src/gui/aggregatorsettings.cpp
@@ -17,6 +17,7 @@
 */
 #include "aggregatorsettings.h"
 
+#include "../base/global.h"
 #include "../base/config.h"
 
 #include <QDebug>

--- a/src/gui/aggregatorsound.cpp
+++ b/src/gui/aggregatorsound.cpp
@@ -29,6 +29,7 @@
 
 #include <QDebug>
 #include <QJsonDocument>
+#include <QCoreApplication>
 
 AggregatorSound::AggregatorSound( QObject* parent ) :
 	QObject( parent )

--- a/src/gui/aggregatorsound.h
+++ b/src/gui/aggregatorsound.h
@@ -19,6 +19,7 @@
 
 #include "../base/position.h"
 
+#include <QPointer>
 #include <QList>
 
 #include "openalwrapper.h"

--- a/src/gui/aggregatortileinfo.cpp
+++ b/src/gui/aggregatortileinfo.cpp
@@ -64,7 +64,7 @@ void AggregatorTileInfo::onShowTileInfo( unsigned int tileID )
 	onUpdateTileInfo( tileID );
 }
 
-void AggregatorTileInfo::onUpdateAnyTileInfo( const QSet<unsigned int>& changeSet )
+void AggregatorTileInfo::onUpdateAnyTileInfo( const std::set<unsigned int>& changeSet )
 {
 	if( !g ) return;
 	if ( changeSet.contains( m_currentTileID ) )

--- a/src/gui/aggregatortileinfo.h
+++ b/src/gui/aggregatortileinfo.h
@@ -117,7 +117,7 @@ private:
 
 public slots:
 	void onShowTileInfo( unsigned int tileID );
-	void onUpdateAnyTileInfo( const QSet<unsigned int>& changeSet );
+	void onUpdateAnyTileInfo( const std::set<unsigned int>& changeSet );
 	void onUpdateTileInfo( unsigned int tileID );
 	void onRequestStockpileItems( unsigned int tileID );
 	void onSetTennant( unsigned int designationID, unsigned int gnomeID );

--- a/src/gui/eventconnector.h
+++ b/src/gui/eventconnector.h
@@ -17,7 +17,11 @@
 */
 #pragma once
 
+#include "../base/enums.h"
+
 #include <QObject>
+#include <QPointer>
+#include <QPointer>
 
 class GameManager;
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -86,7 +86,7 @@
 
 static MainWindow* instance;
 
-static QSet<QString> m_noesisMessages;
+static std::set<QString> m_noesisMessages;
 
 MainWindow::MainWindow( QWidget* parent ) :
 	QOpenGLWindow()

--- a/src/gui/openalwrapper.h
+++ b/src/gui/openalwrapper.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <alc.h>
 #include <efx-presets.h>
+#include <unordered_map>
 
 namespace AL
 {

--- a/src/gui/strings.cpp
+++ b/src/gui/strings.cpp
@@ -85,7 +85,7 @@ QString Strings::randomKingdomName()
 
 QString Strings::replaceNamePart( QString part )
 {
-	QSet<QString> noReplaceables = { "The", "of", "Land", "Kingdom" };
+	std::set<QString> noReplaceables = { "The", "of", "Land", "Kingdom" };
 	if ( noReplaceables.contains( part ) )
 	{
 		return part;

--- a/src/gui/xaml/converters.cpp
+++ b/src/gui/xaml/converters.cpp
@@ -17,6 +17,12 @@
 */
 
 #include "converters.h"
+#include <QString>
+#include <QStringList>
+#include <NsCore/Package.h>
+#include <NsGui/Brush.h>
+#include <NsGui/SolidColorBrush.h>
+#include <NsDrawing/Color.h>
 
 using namespace IngnomiaGUI;
 using namespace Noesis;

--- a/src/gui/xaml/converters.h
+++ b/src/gui/xaml/converters.h
@@ -20,6 +20,7 @@
 
 #include <NsCore/Noesis.h>
 #include <NsCore/ReflectionDeclare.h>
+#include <NsGui/BaseValueConverter.h>
 
 namespace IngnomiaGUI
 {


### PR DESCRIPTION
As mentioned on Discord, this is the first step towards removal of Qt. It includes the following changes:

1. This first set of changes just removes `QSet` completely, because it was the easiest
2. I've changed the C++ version to C++20, because the STL has improved a lot on that version, it makes things easier without extra libs. This can be reverted to 17, specially if we use something like Abseil instead of STL (another incoming PR does this, so it's just a matter of deciding if this is wanted or not)
3. Because of C++20, Linux now compiles with GCC 10 (instead of the previous GCC 7). Even when reverting back to C++17, using a more modern compiler might be a good idea.

As mentioned, I'm opening a separate PR to add Abseil instead of STL.

I haven't "played" through every single change, but every commit compiles on its own and a new game can be started for each one of them.